### PR TITLE
Do not install jupyter in conda environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN /usr/bin/pip3 install          \
     'nglview'                      \
     'voila'
 
+RUN python -m ipykernel install
+
 # Enable extensions.
 RUN /usr/local/bin/jupyter serverextension enable --py --sys-prefix nbserverproxy
 RUN /usr/local/bin/jupyter nbextension     enable --py --sys-prefix appmode

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,13 +51,13 @@ RUN /usr/bin/pip3 install          \
     'voila'
 
 # Enable extensions.
-RUN /usr/local/bin/jupyter serverextension enable --sys-prefix --py nbserverproxy
+RUN /usr/local/bin/jupyter serverextension enable --py --sys-prefix nbserverproxy
 RUN /usr/local/bin/jupyter nbextension     enable --py --sys-prefix appmode
 RUN /usr/local/bin/jupyter serverextension enable --py --sys-prefix appmode
 RUN /usr/local/bin/jupyter nbextension enable nglview --py --sys-prefix
 # TODO: delete, when https://github.com/aiidalab/aiidalab-widgets-base/issues/31 is fixed
 # the fileupload extension also needs to be "installed".
-RUN /usr/local/bin/jupyter nbextension install --sys-prefix --py fileupload
+RUN /usr/local/bin/jupyter nbextension install --py --sys-prefix fileupload
 
 # Enables better integration with Jupyter Hub.
 # https://jupyterlab.readthedocs.io/en/stable/user/jupyterhub.html#further-integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,6 @@ RUN /usr/bin/pip3 install          \
     'nglview'                      \
     'voila'
 
-RUN python -m ipykernel install --user
-
 # Enable extensions.
 RUN /usr/local/bin/jupyter serverextension enable --sys-prefix --py nbserverproxy
 RUN /usr/local/bin/jupyter nbextension     enable --py --sys-prefix appmode

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Quantum-Espresso Pseudo Potentials.
+# TODO, remove when https://github.com/aiidateam/aiida-sssp/pull/25 is merged
+# and installed on AiiDA lab
 WORKDIR /opt/pseudos
 RUN base_url=http://archive.materialscloud.org/file/2018.0001/v3;  \
 wget ${base_url}/SSSP_efficiency_pseudos.aiida;                    \
@@ -53,6 +55,8 @@ RUN /usr/bin/pip3 install          \
 RUN python -m ipykernel install
 
 # Enable extensions.
+# NOTE: for this to work I had to install nglview and appmode-aiidalab to the
+# /usr/bin/pip3 python environment
 RUN /usr/local/bin/jupyter serverextension enable --py --sys-prefix nbserverproxy
 RUN /usr/local/bin/jupyter nbextension     enable --py --sys-prefix appmode
 RUN /usr/local/bin/jupyter serverextension enable --py --sys-prefix appmode

--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -91,3 +91,6 @@ if [ ! -e /home/${SYSTEM_USER}/apps ]; then
   git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
  cd -
 fi
+
+# Activate the right python kernel.
+python -m ipykernel install --user

--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -91,6 +91,3 @@ if [ ! -e /home/${SYSTEM_USER}/apps ]; then
   git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
  cd -
 fi
-
-# Activate the right python kernel.
-python -m ipykernel install --user

--- a/opt/start-notebook.sh
+++ b/opt/start-notebook.sh
@@ -13,7 +13,7 @@ cd /home/${SYSTEM_USER}
 if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
 
   # Launched by JupyterHub, use single-user entrypoint.
-  /opt/conda/bin/python /opt/aiidalab-singleuser                     \
+  /usr/bin/python /opt/aiidalab-singleuser                           \
       --ip=0.0.0.0                                                   \
       --port=8888                                                    \
       --notebook-dir="/home/${SYSTEM_USER}"                          \
@@ -22,7 +22,7 @@ if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
 else
 
   # Otherwise launch notebook server directly.
-  jupyter-notebook                                                   \
+  /usr/local/bin/jupyter-notebook                                    \
       --ip=0.0.0.0                                                   \
       --port=8888                                                    \
       --no-browser                                                   \


### PR DESCRIPTION
Previously, everything was installed in the base conda environment,
however, this created some problems in coupling jupyter with AiiDA
which requires tornado to be lower than 5.0.0. To fix this problem
this PR installs jupyter in a 'root' environment, but configures it
to use the ipykernel from the base conda environment.