### PR TITLE
Use openssl for token generation.

### DIFF
--- a/run_aiidalab.sh
+++ b/run_aiidalab.sh
@@ -12,7 +12,7 @@ fi
 
 PORT=${1}
 FOLDER=${2}
-TOKEN=`date | md5`
+TOKEN=`openssl rand -hex 32`
 IMAGE='aiidalab/aiidalab-docker-stack:latest'
 
 echo "Pulling the image from the Docker Hub..."


### PR DESCRIPTION
Inspired by: https://jupyterhub.readthedocs.io/en/stable/getting-started/security-basics.html#generating-and-storing-as-a-cookie-secret-file

Tested for for Ubuntu 18.04 and on Mac OS-X 10.11.6.

Caveat: Requires the installation of openssl at least on Mac OS-X.