### PR TITLE
Allow force on creation of symlink as it fails if it already exists

### DIFF
--- a/my_init.d/prepare-aiidalab.sh
+++ b/my_init.d/prepare-aiidalab.sh
@@ -2,6 +2,6 @@
 set -em
 
 # For backwards compatibility
-ln -s /home/${SYSTEM_USER} /project 
+ln -sf /home/${SYSTEM_USER} /project 
 
 su -c /opt/prepare-aiidalab.sh ${SYSTEM_USER}


### PR DESCRIPTION
If symlink exists we need can use the force options to avoid termination.