### PR TITLE
Revert "Install ripgrep by default."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update && apt-get install -y  \
     python3-setuptools    \
     python3-wheel         \
     quantum-espresso      \
-    ripgrep               \
   && rm -rf /var/lib/apt/lists/*
 
 # Install what is needed for Jupyter Lab.


### PR DESCRIPTION
Reverts aiidalab/aiidalab-docker-stack#73

Unfortunately, Ubuntu 18.04 does not have an easy way to install `ripgrep`. 
Ubuntu 18.10 is the lowest version that natively supports it, see:
https://github.com/BurntSushi/ripgrep/issues/1232#issuecomment-478235984
Therefore, we first need to upgrade our base ubuntu image first, see:
https://github.com/aiidateam/aiida-prerequisites/issues/15