### PR TITLE
Pin the aiida-core base image version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-core:latest
+FROM aiidateam/aiida-core:1.2.1
 
 LABEL maintainer="Materials Cloud Team <aiidalab@materialscloud.org>"
 


### PR DESCRIPTION
To ensure that our image builds are reproducible and do not break due to
random upstream updates.