### PR TITLE
Enable continuous integrated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,36 +7,36 @@ on:
 
 jobs:
 
-  build-docker-image:
+  #build-docker-image:
 
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+  #  runs-on: ubuntu-latest
+  #  timeout-minutes: 15
 
-    outputs:
-      image: ${{ steps.tag.outputs.image }}
+  #  outputs:
+  #    image: ${{ steps.tag.outputs.image }}
 
-    steps:
-      - uses: actions/checkout@v2
+  #  steps:
+  #    - uses: actions/checkout@v2
 
-      - name: build image
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_with_ref: true
-          tag_with_sha: true
-          cache_froms: "aiidalab/aiidalab-docker-stack:latest,aiidalab/aiidalab-docker-stack:stable,aiidateam/aiida-core:latest"
+  #    - name: build image
+  #      uses: docker/build-push-action@v1
+  #      with:
+  #        username: ${{ secrets.DOCKER_USERNAME }}
+  #        password: ${{ secrets.DOCKER_PASSWORD }}
+  #        tag_with_ref: true
+  #        tag_with_sha: true
+  #        cache_froms: "aiidalab/aiidalab-docker-stack:latest,aiidalab/aiidalab-docker-stack:stable,aiidateam/aiida-core:latest"
 
-      - name: set output image
-        id: tag
-        run: |
-          IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
-          echo "::set-output name=image::${{ github.repository }}:sha-${IMAGE_REF}"
+  #    - name: set output image
+  #      id: tag
+  #      run: |
+  #        IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
+  #        echo "::set-output name=image::${{ github.repository }}:sha-${IMAGE_REF}"
 
   test-apps:
 
     runs-on: ubuntu-latest
-    needs: build-docker-image
+    #needs: build-docker-image
     timeout-minutes: 15
 
     strategy:
@@ -59,4 +59,5 @@ jobs:
       - name: Test app
         uses: aiidalab/aiidalab-test-app-action@releases/v2
         with:
-          image: ${{ needs.build-docker-image.outputs.image }}
+          image: aiidalab/aiidalab-docker-stack:latest
+          #image: ${{ needs.build-docker-image.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           repository: ${{ matrix.app }}
 
       - name: Test app
-        uses: aiidalab/aiidalab-test-app-action@releases/v2
+        uses: aiidalab/aiidalab-test-app-action@v2-selenium
         with:
           image: aiidalab/aiidalab-docker-stack:latest
           #image: ${{ needs.build-docker-image.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,36 +7,36 @@ on:
 
 jobs:
 
-  #build-docker-image:
+  build-docker-image:
 
-  #  runs-on: ubuntu-latest
-  #  timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-  #  outputs:
-  #    image: ${{ steps.tag.outputs.image }}
+    outputs:
+      image: ${{ steps.tag.outputs.image }}
 
-  #  steps:
-  #    - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-  #    - name: build image
-  #      uses: docker/build-push-action@v1
-  #      with:
-  #        username: ${{ secrets.DOCKER_USERNAME }}
-  #        password: ${{ secrets.DOCKER_PASSWORD }}
-  #        tag_with_ref: true
-  #        tag_with_sha: true
-  #        cache_froms: "aiidalab/aiidalab-docker-stack:latest,aiidalab/aiidalab-docker-stack:stable,aiidateam/aiida-core:latest"
+      - name: build image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_with_ref: true
+          tag_with_sha: true
+          cache_froms: "aiidalab/aiidalab-docker-stack:latest,aiidalab/aiidalab-docker-stack:stable,aiidateam/aiida-core:latest"
 
-  #    - name: set output image
-  #      id: tag
-  #      run: |
-  #        IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
-  #        echo "::set-output name=image::${{ github.repository }}:sha-${IMAGE_REF}"
+      - name: set output image
+        id: tag
+        run: |
+          IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
+          echo "::set-output name=image::${{ github.repository }}:sha-${IMAGE_REF}"
 
   test-apps:
 
     runs-on: ubuntu-latest
-    #needs: build-docker-image
+    needs: build-docker-image
     timeout-minutes: 10
 
     strategy:
@@ -61,6 +61,5 @@ jobs:
       - name: Test app
         uses: aiidalab/aiidalab-test-app-action@v2-beta
         with:
-          image: aiidalab/aiidalab-docker-stack:latest
-          #image: ${{ needs.build-docker-image.outputs.image }}
+          image: ${{ needs.build-docker-image.outputs.image }}
           browser: ${{ matrix.browser }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         id: tag
         run: |
           IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
-          echo "::set-output name=image::sha-${IMAGE_REF}"
+          echo "::set-output name=image::${{ github.repository }}:sha-${IMAGE_REF}"
 
   test-apps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
         app: [
             aiidalab/aiidalab-home,
             csadorf/aiidalab-hello-world,
-            #aiidalab/aiidalab-widgets-base,
-            #aiidalab/aiidalab-qe,
-            #aiidalab/aiidalab-optimade,
+            aiidalab/aiidalab-widgets-base,
+            aiidalab/aiidalab-qe,
+            aiidalab/aiidalab-optimade,
           ]
         browser: [ chrome ] # firefox ]
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+# Run basic tests for this app on the latest aiidalab-docker image.
+
+name: continuous-integration
+
+on:
+  [push]
+
+jobs:
+
+  build-docker-image:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: build image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_with_ref: true
+          tag_with_sha: true
+
+  test-apps:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        app: [csadorf/aiidalab-hello-world]
+
+    steps:
+
+      - name: Checkout app
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.app }}
+
+      - name: Test app
+        uses: aiidalab/aiidalab-test-app-action@releases/v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,13 @@ jobs:
 
     strategy:
       matrix:
-        app: [csadorf/aiidalab-hello-world]
+        app: [
+            csadorf/aiidalab-hello-world,
+            aiidalab/aiidalab-home,
+            aiidalab/aiidalab-qe,
+            aiidalab/aiidalab-widgets-base,
+            aiidalab/aiidalab-optimade,
+          ]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    outputs:
+      image: ${{ steps.tag.outputs.image }}
+
     steps:
       - uses: actions/checkout@v2
 
@@ -22,9 +25,16 @@ jobs:
           tag_with_ref: true
           tag_with_sha: true
 
+      - name: set output image
+        id: tag
+        run: |
+          IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
+          echo "::set-output name=image::sha-${IMAGE_REF}"
+
   test-apps:
 
     runs-on: ubuntu-latest
+    needs: build-docker-image
 
     strategy:
       matrix:
@@ -39,3 +49,5 @@ jobs:
 
       - name: Test app
         uses: aiidalab/aiidalab-test-app-action@releases/v2
+        with:
+          image: ${{ needs.build-docker-image.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build-docker-image:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     outputs:
       image: ${{ steps.tag.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,19 @@ jobs:
 
     runs-on: ubuntu-latest
     #needs: build-docker-image
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     strategy:
       matrix:
         app: [
-            csadorf/aiidalab-hello-world,
             aiidalab/aiidalab-home,
-            aiidalab/aiidalab-qe,
-            aiidalab/aiidalab-widgets-base,
-            aiidalab/aiidalab-optimade,
+            csadorf/aiidalab-hello-world,
+            #aiidalab/aiidalab-widgets-base,
+            #aiidalab/aiidalab-qe,
+            #aiidalab/aiidalab-optimade,
           ]
+        browser: [ chrome ] # firefox ]
+      fail-fast: false
 
     steps:
 
@@ -61,3 +63,4 @@ jobs:
         with:
           image: aiidalab/aiidalab-docker-stack:latest
           #image: ${{ needs.build-docker-image.outputs.image }}
+          browser: ${{ matrix.browser }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
     strategy:
       matrix:
         app: [
-            aiidalab/aiidalab-home,
+            # aiidalab/aiidalab-home,  -- failing
             csadorf/aiidalab-hello-world,
             aiidalab/aiidalab-widgets-base,
             aiidalab/aiidalab-qe,
-            aiidalab/aiidalab-optimade,
+            # aiidalab/aiidalab-optimade, -- failing
           ]
         browser: [ chrome ] # firefox ]
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_with_ref: true
           tag_with_sha: true
+          cache_froms: "aiidalab/aiidalab-docker-stack:latest,aiidalab/aiidalab-docker-stack:stable,aiidateam/aiida-core:latest"
 
       - name: set output image
         id: tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           repository: ${{ matrix.app }}
 
       - name: Test app
-        uses: aiidalab/aiidalab-test-app-action@v2-selenium
+        uses: aiidalab/aiidalab-test-app-action@v2-beta
         with:
           image: aiidalab/aiidalab-docker-stack:latest
           #image: ${{ needs.build-docker-image.outputs.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build-docker-image:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     outputs:
       image: ${{ steps.tag.outputs.image }}
@@ -35,6 +36,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: build-docker-image
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             aiidalab/aiidalab-qe,
             # aiidalab/aiidalab-optimade, -- failing
           ]
-        browser: [ chrome ] # firefox ]
+        browser: [ chrome, firefox ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           repository: ${{ matrix.app }}
 
       - name: Test app
-        uses: aiidalab/aiidalab-test-app-action@v2-beta
+        uses: aiidalab/aiidalab-test-app-action@v2
         with:
           image: ${{ needs.build-docker-image.outputs.image }}
           browser: ${{ matrix.browser }}


### PR DESCRIPTION
Enable continuous integrated testing for this repository.

The tests are implemented as part of the `continuous-integration` GitHub actions workflow which consists of two jobs:

1. Build the docker image and push it to docker hub tagged with both the ref (branch name) and the sha1.
2. Run the `aiidalab-test-app-action` action for a hard-coded set of continuously tested apps.

The list of apps should be extended in the future and we might need to devise a different mechanism of generating that list, but for now this will suffice.