### PR TITLE
Enable continuous integrated testing with GitHub actions workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+# Run basic tests for this app on the latest aiidalab-docker image.
+
+name: continuous-integration
+
+on:
+  [push]
+
+jobs:
+
+  build-docker-image:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    outputs:
+      image: ${{ steps.tag.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: build image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_with_ref: true
+          tag_with_sha: true
+          cache_froms: "aiidalab/aiidalab-docker-stack:latest,aiidalab/aiidalab-docker-stack:stable,aiidateam/aiida-core:latest"
+
+      - name: set output image
+        id: tag
+        run: |
+          IMAGE_REF=`echo ${{ github.sha }} | sed 's/^\(.......\).*/\1/'`
+          echo "::set-output name=image::${{ github.repository }}:sha-${IMAGE_REF}"
+
+  test-apps:
+
+    runs-on: ubuntu-latest
+    needs: build-docker-image
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        app: [
+            # aiidalab/aiidalab-home,  -- failing
+            aiidalab/aiidalab-hello-world,
+            aiidalab/aiidalab-widgets-base,
+            aiidalab/aiidalab-qe,
+            # aiidalab/aiidalab-optimade, -- failing
+          ]
+        browser: [ chrome, firefox ]
+      fail-fast: false
+
+    steps:
+
+      - name: Checkout app
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.app }}
+
+      - name: Test app
+        uses: aiidalab/aiidalab-test-app-action@v2
+        with:
+          image: ${{ needs.build-docker-image.outputs.image }}
+          browser: ${{ matrix.browser }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
-# Run basic tests for this app on the latest aiidalab-docker image.
+# Execute continuous integration tests for this docker image. This is to ensure that
+# new versions of the image do not break currently expected behavior and that the
+# environment provided by this image is compatible with a selected set of apps.
 
 name: continuous-integration
 
@@ -53,11 +55,27 @@ jobs:
 
     steps:
 
+      # This step checks out the app (not the docker image repository!) that will be
+      # mounted onto an aiidalab container instance with the image built in the
+      # previous job.
       - name: Checkout app
         uses: actions/checkout@v2
         with:
           repository: ${{ matrix.app }}
 
+      # Start the aiida lab instance with the docker image built in the previous job.
+      # The container is launched as part of a network with a selenium hub.
+      # The app checked out in the previous step is mounted into the container under
+      # `/home/aiida/apps/app`.
+      #
+      # Then execute platform and app tests that include backend and frontend tests
+      # implemented as unit tests and browser tests (with selenium), e.g., check that
+      # notebooks that are part of the app can be openend in the browser in app mode
+      # without triggering an exception.
+      #
+      # Please refer to the action's documentation for more information on what tests
+      # in particular are executed and how to implement new tests for both the aiida
+      # lab platform and aiida lab apps.
       - name: Test app
         uses: aiidalab/aiidalab-test-app-action@v2
         with:


### PR DESCRIPTION
Enable continuous integrated testing for this repository.

The tests are implemented as part of the `continuous-integration` GitHub actions workflow which consists of two jobs:

1. Build the docker image and push it to docker hub tagged with both the ref (branch name) and the sha1.
2. Run the [aiidalab-test-app-action](https://github.com/aiidalab/aiidalab-test-app-action) for a hard-coded set of continuously tested apps.

The list of apps should be extended in the future and we might need to devise a different mechanism of generating that list, but for now this will suffice.

The home app is currently failing which is why the tests for the home app are disabled.
However I'd like to merge this anyways and then fix the issues with the home app as part of a separate PR.