### PR TITLE
Skip installation of apps that are already installed.

### DIFF
--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -47,10 +47,12 @@ if [ ! -e /home/${SYSTEM_USER}/apps ] || [ "${AIIDALAB_SETUP}" == "true" ]; then
   touch /home/${SYSTEM_USER}/apps/__init__.py
 
   # First install the home app.
-  git clone https://github.com/aiidalab/aiidalab-home /home/${SYSTEM_USER}/apps/home
-  cd /home/${SYSTEM_USER}/apps/home
-  git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
-  cd -
+  if [ ! -e /home/${SYSTEM_USER}/apps/home ]; then
+    git clone https://github.com/aiidalab/aiidalab-home /home/${SYSTEM_USER}/apps/home
+    cd /home/${SYSTEM_USER}/apps/home
+    git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
+    cd -
+  fi
 
   # Define the order how the apps should appear.
   echo '{
@@ -61,13 +63,17 @@ if [ ! -e /home/${SYSTEM_USER}/apps ] || [ "${AIIDALAB_SETUP}" == "true" ]; then
     ]
   }' > /home/${SYSTEM_USER}/apps/home/.launcher.json
 
-  git clone https://github.com/aiidalab/aiidalab-widgets-base /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
-  cd /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
-  git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
-  cd -
+  if [ ! -e /home/${SYSTEM_USER}/apps/aiidalab-widgets-base ]; then
+    git clone https://github.com/aiidalab/aiidalab-widgets-base /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
+    cd /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
+    git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
+    cd -
+  fi
 
-  git clone https://github.com/aiidalab/aiidalab-qe.git /home/${SYSTEM_USER}/apps/quantum-espresso
-  cd /home/${SYSTEM_USER}/apps/quantum-espresso
-  git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
- cd -
+  if [ ! -e /home/${SYSTEM_USER}/apps/quantum-espresso ]; then
+    git clone https://github.com/aiidalab/aiidalab-qe.git /home/${SYSTEM_USER}/apps/quantum-espresso
+    cd /home/${SYSTEM_USER}/apps/quantum-espresso
+    git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
+    cd -
+  fi
 fi


### PR DESCRIPTION
Even when aiidalab is not already setup. This is to enable tests runs
where these particular apps are already mounted into that particular
path.

This is to enable tests of the home app, QE app, and eventually aiidalab-widgets-base. Partially addresses the issue encountered here: https://github.com/aiidalab/aiidalab-home/pull/42#issuecomment-673626447