### PR TITLE
Bind home application with aiidalab-docker-stack container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ COPY opt/prepare-aiidalab.sh /opt/
 COPY my_init.d/prepare-aiidalab.sh /etc/my_init.d/80_prepare-aiidalab.sh
 
 # Get aiidalab-home app.
-RUN git clone https://github.com/aiidalab/aiidalab-home
+RUN git clone --branch='master' --single-branch --depth=1 https://github.com/aiidalab/aiidalab-home
 RUN chmod 774 aiidalab-home
 
 # Copy scripts to start Jupyter notebook.

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,10 @@ COPY opt/aiidalab-singleuser /opt/
 COPY opt/prepare-aiidalab.sh /opt/
 COPY my_init.d/prepare-aiidalab.sh /etc/my_init.d/80_prepare-aiidalab.sh
 
+# Get aiidalab-home app.
+RUN git clone https://github.com/aiidalab/aiidalab-home
+RUN chmod 774 aiidalab-home
+
 # Copy scripts to start Jupyter notebook.
 COPY opt/start-notebook.sh /opt/
 COPY service/jupyter-notebook /etc/service/jupyter-notebook/run

--- a/my_init.d/prepare-aiidalab.sh
+++ b/my_init.d/prepare-aiidalab.sh
@@ -4,4 +4,7 @@ set -em
 # For backwards compatibility
 ln -sf /home/${SYSTEM_USER} /project 
 
+# Change group of the aiidalab-home folder
+chown root:${SYSTEM_USER} -R /opt/aiidalab-home
+
 su -c /opt/prepare-aiidalab.sh ${SYSTEM_USER}

--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -51,6 +51,8 @@ if [ ! -e /home/${SYSTEM_USER}/apps/home ]; then
     echo "Install home app."
     ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
 elif [[ -d /home/${SYSTEM_USER}/apps/home && ! -L /home/${SYSTEM_USER}/apps/home ]]; then
+  # Here we perform a transition of existing aiidalab accounts. We are backing up the home app folder and 
+  # replacing it with a link to `/opt/aiidalab-home`.
   mv /home/${SYSTEM_USER}/apps/home /home/${SYSTEM_USER}/apps/.home~`date --iso-8601=seconds`
   ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
 fi

--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -51,7 +51,7 @@ if [ ! -e /home/${SYSTEM_USER}/apps/home ]; then
     echo "Install home app."
     ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
 elif [[ -d /home/${SYSTEM_USER}/apps/home && ! -L /home/${SYSTEM_USER}/apps/home ]]; then
-  mv /home/${SYSTEM_USER}/apps/home /home/${SYSTEM_USER}/apps/.home-`date --iso-8601=seconds`
+  mv /home/${SYSTEM_USER}/apps/home /home/${SYSTEM_USER}/apps/.home~`date --iso-8601=seconds`
   ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
 fi
 
@@ -72,4 +72,3 @@ if [[ ${INITIAL_SETUP} == true ||  "${AIIDALAB_SETUP}" == "true" ]]; then
     cd -
   fi
 fi
-

--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -38,38 +38,33 @@ if __name__ == "__main__":
 EOF
 fi
 
-# Install/upgrade apps.
-if [ ! -e /home/${SYSTEM_USER}/apps ] || [ "${AIIDALAB_SETUP}" == "true" ]; then
-   echo "Install / upgrade apps..."
-
+# Create apps folder and make its subfolders importable from Python.
+if [ ! -e /home/${SYSTEM_USER}/apps ]; then
   # Create apps folder and make it importable from python.
   mkdir -p /home/${SYSTEM_USER}/apps
   touch /home/${SYSTEM_USER}/apps/__init__.py
+  INITIAL_SETUP=true
+fi
 
-  # First install the home app.
-  if [ ! -e /home/${SYSTEM_USER}/apps/home ]; then
-    git clone https://github.com/aiidalab/aiidalab-home /home/${SYSTEM_USER}/apps/home
-    cd /home/${SYSTEM_USER}/apps/home
-    git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
-    cd -
-  fi
+# Install the home app.
+if [ ! -e /home/${SYSTEM_USER}/apps/home ]; then
+    echo "Install home app."
+    ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
+elif [[ -d /home/${SYSTEM_USER}/apps/home && ! -L /home/${SYSTEM_USER}/apps/home ]]; then
+  mv /home/${SYSTEM_USER}/apps/home /home/${SYSTEM_USER}/apps/.home-`date --iso-8601=seconds`
+  ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
+fi
 
-  # Define the order how the apps should appear.
-  echo '{
-    "hidden": [],
-    "order": [
-      "aiidalab-widgets-base",
-      "quantum-espresso"
-    ]
-  }' > /home/${SYSTEM_USER}/apps/home/.launcher.json
-
+# Install/upgrade apps.
+if [[ ${INITIAL_SETUP} == true ||  "${AIIDALAB_SETUP}" == "true" ]]; then
+  # Base widgets app.
   if [ ! -e /home/${SYSTEM_USER}/apps/aiidalab-widgets-base ]; then
     git clone https://github.com/aiidalab/aiidalab-widgets-base /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
     cd /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
     git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
     cd -
-  fi
-
+  fi 
+  # Quantum Espresso app.
   if [ ! -e /home/${SYSTEM_USER}/apps/quantum-espresso ]; then
     git clone https://github.com/aiidalab/aiidalab-qe.git /home/${SYSTEM_USER}/apps/quantum-espresso
     cd /home/${SYSTEM_USER}/apps/quantum-espresso
@@ -77,3 +72,4 @@ if [ ! -e /home/${SYSTEM_USER}/apps ] || [ "${AIIDALAB_SETUP}" == "true" ]; then
     cd -
   fi
 fi
+

--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -49,10 +49,17 @@ fi
 # Install the home app.
 if [ ! -e /home/${SYSTEM_USER}/apps/home ]; then
     echo "Install home app."
+    # The home app is installed in system space and linked to from user space.
+    # That ensures that users are not inadvertently running the wrong version of
+    # the home app for a given system environment, but still makes it possible to
+    # manually install a specific version of the home app in between upgrades, e.g.,
+    # for development work, by simply replacing the link with a clone of the repository.
     ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
 elif [[ -d /home/${SYSTEM_USER}/apps/home && ! -L /home/${SYSTEM_USER}/apps/home ]]; then
-  # Here we perform a transition of existing aiidalab accounts. We are backing up the home app folder and 
-  # replacing it with a link to `/opt/aiidalab-home`.
+  # Backup an existing repository of the home app and replace with link to /opt/aiidalab-home.
+  # This mechanism preserves potential development work on a manually installed repository
+  # of the home app and also constitutes a migration path for existing aiidalab accounts, where
+  # the home app was installed directly into user space by default.
   mv /home/${SYSTEM_USER}/apps/home /home/${SYSTEM_USER}/apps/.home~`date --iso-8601=seconds`
   ln -s /opt/aiidalab-home /home/${SYSTEM_USER}/apps/home
 fi


### PR DESCRIPTION
Home app is now downloaded into `/opt` folder and installed via link.
To ensure smooth transition of the existing aiidalab accounts the old
home app will be automatically backuped and replaced with a link to
the `/opt/aiidalab-home` folder named `home`.