### PR TITLE
Don't install dscribe, update OPTIMADE.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN /usr/local/bin/jupyter nbextension enable widget_periodictable --user --py
 
 # Install OPTIMADE.
 WORKDIR /opt/
-RUN git clone https://github.com/aiidalab/aiidalab-optimade.git && cd aiidalab-optimade && git reset --hard e008ca3f00bfbcceea52512e7dfe1c24f803c775
+RUN git clone https://github.com/aiidalab/aiidalab-optimade.git && cd aiidalab-optimade && git reset --hard 25d56cc8ae992044265aaaad4968d904b4afb487
 RUN pip install ./aiidalab-optimade
 
 # Install some useful packages that are not available on PyPi

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,6 @@ RUN pip install ./aiidalab-optimade
 # Install some useful packages that are not available on PyPi
 RUN conda install --yes -c conda-forge rdkit
 RUN conda install --yes -c openbabel openbabel
-RUN conda install --yes -c conda-forge dscribe "tornado<5"
 
 # Prepare user's folders for AiiDA lab launch.
 COPY opt/aiidalab-singleuser /opt/


### PR DESCRIPTION
Dscribe package pulls ASE==3.19.1 as the dependency, which overrides
ASE==3.20.1 installed as the dependency of the aiidalab package. In
the future the users who want to use dscribe may install it themselves.