### PR TITLE
Use v1.0.0 of aiidalab-optimade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN /usr/local/bin/jupyter nbextension enable widget_periodictable --user --py
 
 # Install OPTIMADE.
 WORKDIR /opt/
-RUN git clone https://github.com/aiidalab/aiidalab-optimade.git && cd aiidalab-optimade && git reset --hard v3.3.2+aiidalab
+RUN git clone https://github.com/aiidalab/aiidalab-optimade.git && cd aiidalab-optimade && git reset --hard v1.0.0
 RUN pip install ./aiidalab-optimade
 
 # Install some useful packages that are not available on PyPi


### PR DESCRIPTION
This is the new edition of the AiiDAlab-specific OPTIMADE Client application.

Note, depending on the outcome of the `numpy` dependency discussion, this version may change, hence this is a draft PR until that has been decided.