### PR TITLE
CI: Always try to upload screenshots even if (some) tests failed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           bundled: ${{ matrix.app[2] }}
 
       - name: Upload screenshots as artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: Screenshots-${{ matrix.app[1] }}-${{ matrix.browser }}


### PR DESCRIPTION
Ensure that screenshots artifacts are uploaded even if one or more test failed. Should make it a bit easier to debug failing workflows.