### PR TITLE
Revert "Set AIIDALAB_ENVIRONMENT_VERSION to 1.0.0 (#128)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,9 +118,6 @@ COPY service/jupyter-notebook /etc/service/jupyter-notebook/run
 # Expose port 8888.
 EXPOSE 8888
 
-# Set the AiiDAlab environment version.
-ENV AIIDALAB_ENVIRONMENT_VERSION 1.0.0
-
 # Remove when the following issue is fixed: https://github.com/jupyterhub/dockerspawner/issues/319.
 COPY my_my_init /sbin/my_my_init
 


### PR DESCRIPTION
This reverts commit cfe2b9c3b7245502911eb4aa94fbba9fdfa4535d.

We will need to slightly adjust the app dependency management to allow for the release on Quantum Mobile. This change set reverts #128 to allow for an intermittent release.