### PR TITLE
Pin the aiidalab-widgets base version.

### DIFF
--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -71,6 +71,7 @@ if [[ ${INITIAL_SETUP} == true ||  "${AIIDALAB_SETUP}" == "true" ]]; then
     git clone https://github.com/aiidalab/aiidalab-widgets-base /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
     cd /home/${SYSTEM_USER}/apps/aiidalab-widgets-base
     git checkout ${AIIDALAB_DEFAULT_GIT_BRANCH}
+    git reset --hard v1.0.0b14
     cd -
   fi 
   # Quantum Espresso app.


### PR DESCRIPTION
Otherwise a push to the aiidalab-widgets-base repository has potential
to break new aiidalab user instances.