### PR TITLE
Add ipytree to dependencies.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ binaryornot = "~=0.4.4"
 bokeh = "~=1.4" # Older versions require tornado to be higher than 5.0
 bqplot = "~=0.12.0"
 cookiecutter = "~=1.6.0"
+ipytree = "~=0.1.8"  # required by qe-app
 ipywidgets = "<8.0.0"
 lxml = "~=4.5.0"
 Markdown = "~=3.1.1"


### PR DESCRIPTION
Required by the QE app.