### PR TITLE
Remove ipytree dependency from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,6 @@ binaryornot = "~=0.4.4"
 bokeh = "~=1.4" # Older versions require tornado to be higher than 5.0
 bqplot = "~=0.12.0"
 cookiecutter = "~=1.6.0"
-ipytree = "~=0.1.8"  # required by qe-app
 ipywidgets = "<8.0.0"
 lxml = "~=4.5.0"
 Markdown = "~=3.1.1"


### PR DESCRIPTION
This dependency will be implicitly required by aiidalab-widgets-base.

Fixes #168 .