### PR TITLE
Remove deployment docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,9 @@ This repo contains the Docker file used in the [AiiDAlab](https://www.materialsc
 Docker images are available from Dockerhub via `docker pull aiidalab/aiidalab-docker-stack:latest`.
 See [aiidalab/aiidalab-docker-stack](https://hub.docker.com/repository/docker/aiidalab/aiidalab-docker-stack) for a list of available tags.
 
-# Deploy on AiiDAlab server
+# Documentation
 
-To deploy changes, log into the AiiDAlab server and execute the following commands:
-```
-docker pull aiidalab/aiidalab-docker-stack:latest
-docker tag aiidalab/aiidalab-docker-stack:latest aiidalab-docker-stack:latest
-```
-The users will gradually pick up the new image, whenever they restart their container via the _Control Panel_.
-
-# Deploy locally
-
-Make sure that Docker is installed on your machine, otherwise go to [Docker installation page](http://www.docker.com/install)
-and follow the instructions for your operating system.
-
-Then, start AiiDAlab:
-```
-./run.sh PORT PATH_TO_AIIDALAB_HOME_DIR
-```
-
-Where `PORT` is any free port on your machine (typically it is 8888) and `PATH_TO_AIIDALAB_HOME_DIR` is an absolute path to the folder where user's data will be stored
-(typically it is something like `${HOME}/aiidalab`).
-The last line of the output of the command above will contain the link to access AiiDAlab in your browser.
-
-# Slow IO
-
-To check for issues with OpenStack's block storage observe the following command for a **few minutes**:
-```
-watch -n 0.1 "ps axu| awk '{print \$8, \"   \", \$11}' | sort | head -n 10"
-```
-Pretty much all processes should be in the `S` state. If a process stays in the `D` state for a longer time it is most likely waiting for slow IO.
+Please see the [AiiDAlab documentation](https://aiidalab.readthedocs.io/) for information on how to use and deploy AiiDAlab docker images.
 
 ## Citation
 


### PR DESCRIPTION
fix https://github.com/aiidalab/aiidalab-docker-stack/issues/195

Point to AiiDAlab docs instead to reduce duplication.