### PR TITLE
CI: always display the container log (before and after container restart).

### DIFF
--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -67,4 +67,4 @@ jobs:
       -
         name: Show container log (before the restart).
         if: always()
-        run: docker logs ${{ stepst.test_run.outputs.docker_id_1 }}
+        run: docker logs ${{ steps.test_run.outputs.docker_id_1 }}

--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           mkdir tmp
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest`
-          echo "::set-output name=docker_id_before::${DOCKDERID}"
+          echo "::set-output name=docker_id_before::${DOCKERID}"
           docker exec --tty --user root $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/10/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
@@ -61,7 +61,7 @@ jobs:
           sudo cp tmp/.ssh/id_rsa . # Copy id_rsa file from the mounted folder.
           docker stop $DOCKERID # Stop the container.
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest` # Start a new container using the same mounted folder.
-          echo "::set-output name=docker_id_after::${DOCKDERID}"
+          echo "::set-output name=docker_id_after::${DOCKERID}"
           docker exec --tty $DOCKERID wait-for-services
           sudo diff id_rsa tmp/.ssh/id_rsa # Check that the id_rsa file wasn't modified.
       -

--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           mkdir tmp
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest`
-          echo ""::set-output name=docker_id_before::${DOCKDERID}""
+          echo "::set-output name=docker_id_before::${DOCKDERID}"
           docker exec --tty --user root $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/10/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
@@ -61,7 +61,7 @@ jobs:
           sudo cp tmp/.ssh/id_rsa . # Copy id_rsa file from the mounted folder.
           docker stop $DOCKERID # Stop the container.
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest` # Start a new container using the same mounted folder.
-          echo ""::set-output name=docker_id_after::${DOCKDERID}""
+          echo "::set-output name=docker_id_after::${DOCKDERID}"
           docker exec --tty $DOCKERID wait-for-services
           sudo diff id_rsa tmp/.ssh/id_rsa # Check that the id_rsa file wasn't modified.
       -

--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           mkdir tmp
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest`
-          echo "::set-output name=docker_id_before::${DOCKERID}"
+          echo "::set-output name=docker_id_first_run::${DOCKERID}"
           docker exec --tty --user root $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/10/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
@@ -61,14 +61,14 @@ jobs:
           sudo cp tmp/.ssh/id_rsa . # Copy id_rsa file from the mounted folder.
           docker stop $DOCKERID # Stop the container.
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest` # Start a new container using the same mounted folder.
-          echo "::set-output name=docker_id_after::${DOCKERID}"
+          echo "::set-output name=docker_id_second_run::${DOCKERID}"
           docker exec --tty $DOCKERID wait-for-services
           sudo diff id_rsa tmp/.ssh/id_rsa # Check that the id_rsa file wasn't modified.
       -
-        name: Show the container log (before the restart).
+        name: Show the container log (first run).
         if: always()
-        run: docker logs "${{ steps.test_run.outputs.docker_id_before }}"
+        run: docker logs "${{ steps.test_run.outputs.docker_id_first_run }}"
       -
-        name: Show the container log (after the restart).
+        name: Show the container log (second run).
         if: always()
-        run: docker logs "${{ steps.test_run.outputs.docker_id_after }}"
+        run: docker logs "${{ steps.test_run.outputs.docker_id_second_run }}"

--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           mkdir tmp
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest`
-          echo ""::set-output name=docker_id_1::${DOCKDERID}""
+          echo ""::set-output name=docker_id_before::${DOCKDERID}""
           docker exec --tty --user root $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/10/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
@@ -61,10 +61,14 @@ jobs:
           sudo cp tmp/.ssh/id_rsa . # Copy id_rsa file from the mounted folder.
           docker stop $DOCKERID # Stop the container.
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest` # Start a new container using the same mounted folder.
-          echo ""::set-output name=docker_id_2::${DOCKDERID}""
+          echo ""::set-output name=docker_id_after::${DOCKDERID}""
           docker exec --tty $DOCKERID wait-for-services
           sudo diff id_rsa tmp/.ssh/id_rsa # Check that the id_rsa file wasn't modified.
       -
-        name: Show container log (before the restart).
+        name: Show the container log (before the restart).
         if: always()
-        run: docker logs ${{ steps.test_run.outputs.docker_id_1 }}
+        run: docker logs "${{ steps.test_run.outputs.docker_id_before }}"
+      -
+        name: Show the container log (after the restart).
+        if: always()
+        run: docker logs "${{ steps.test_run.outputs.docker_id_after }}"

--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -47,9 +47,11 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
       -
         name: Start and test the container
+        id: test_run
         run: |
           mkdir tmp
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest`
+          echo ""::set-output name=docker_id_1::${DOCKDERID}""
           docker exec --tty --user root $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID wait-for-services
           docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/10/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
@@ -59,5 +61,10 @@ jobs:
           sudo cp tmp/.ssh/id_rsa . # Copy id_rsa file from the mounted folder.
           docker stop $DOCKERID # Stop the container.
           export DOCKERID=`docker run -v $PWD/tmp:/home/aiida -d aiidalab-docker-stack:latest` # Start a new container using the same mounted folder.
+          echo ""::set-output name=docker_id_2::${DOCKDERID}""
           docker exec --tty $DOCKERID wait-for-services
           sudo diff id_rsa tmp/.ssh/id_rsa # Check that the id_rsa file wasn't modified.
+      -
+        name: Show container log (before the restart).
+        if: always()
+        run: docker logs ${{ stepst.test_run.outputs.docker_id_1 }}


### PR DESCRIPTION
This functionality is needed to be able to inspect the container log in case of any issues.