### PR TITLE
feat: support notebooks in markdown

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -2,6 +2,8 @@
 jupyterhub==1.5.0
 jupyterlab==3.0.17
 notebook==6.4.1
+# Detect notebooks written in MyST Markdown
+jupytext==1.13.4
 # Dependencies for jupyter widgets
 bqplot==0.12.25
 ipytree==0.1.8


### PR DESCRIPTION
The `jupytext` extension allows writing notebooks in a variety of formats, including Jupytext Markdown, MyST Markdown, etc. which makes for a much more pleasant developer experience, at least for tutorial-style notebooks that also include significant amounts of text (e.g. diffs, no need to worry about cleaning the output before storing in git, etc.).

Note: appmode seems to work with this as well