### PR TITLE
Correctly remove the content of .trash folder

### DIFF
--- a/opt/prepare-aiidalab.sh
+++ b/opt/prepare-aiidalab.sh
@@ -74,7 +74,7 @@ reentry scan
 
 # Clear user trash directory.
 if [ -e /home/${SYSTEM_USER}/.trash ]; then
-  find /home/${SYSTEM_USER}/.trash/ -mindepth 1 -writable -delete
+  rm -rf /home/${SYSTEM_USER}/.trash/*
 fi
 
 # Remove old apps_meta.sqlite requests cache files.


### PR DESCRIPTION
Previously, the `find` was used to delete the trash folder's content.
However, `find` can't delete non-empty folders. A better approach
is to use `rm -rf /home/${SYSTEM_USER}/.trash/*` which should be
more robust.