### PR TITLE
Bump dependencies.

### DIFF
--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -48,7 +48,7 @@ jobs:
                   echo "::set-output name=docker_id_first_run::${DOCKERID}"
                   docker exec --tty --user root $DOCKERID wait-for-services
                   docker exec --tty --user aiida $DOCKERID wait-for-services
-                  docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/10/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
+                  docker exec --tty --user aiida $DOCKERID /bin/bash -l -c '/usr/lib/postgresql/12/bin/pg_ctl -D /home/$SYSTEM_USER/.postgresql status' # Check that postgres is up.
                   docker exec --tty --user root $DOCKERID /bin/bash -l -c 'service rabbitmq-server status' # Check that rabbitmq is up.
                   docker exec --tty --user aiida $DOCKERID /bin/bash -l -c 'conda create -y -n test_env python=3.8' # Check that one can create a new conda environment.
                   docker exec --tty --user aiida $DOCKERID /bin/bash -l -c 'conda activate test_env' # Check that new environment works.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-core:1.6.5-bionic
+FROM aiidateam/aiida-core:1.6.8
 
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,7 +1,7 @@
 # Dependencies for notebook server and interaction with JupyterHub
 jupyterhub==1.5.0
 jupyterlab==3.0.17
-notebook==6.4.10
+notebook==6.4.12
 # Detect notebooks written in MyST Markdown
 jupytext==1.13.4
 # Dependencies for jupyter widgets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiidalab==21.11.1
-aiidalab-widgets-base==1.1.1
+aiidalab==22.02.0
+aiidalab-widgets-base==1.3.3
 binaryornot~=0.4
 bokeh~=2.0
 bqplot~=0.12


### PR DESCRIPTION
- Bump base image version to aiida-core:1.6.8
- Bump aiidalab package to 22.02.0
- Bump aiidalab-widgets-base to 1.3.3

WARNING: this changes the base image version to Ubuntu 20, which comes with a newer PostgreSQL. We do not yet have automated tools to migrate the PostgresSQL database.