### PR TITLE
Use PEP440 mode to determine docker image tags.

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -22,12 +22,12 @@ jobs:
             - uses: actions/checkout@v2
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@v3
+              uses: docker/metadata-action@v4
               with:
                   images: ${{ github.repository }}
                   tags: |
                       type=ref,event=branch
-                      type=match,pattern=v(.*),group=1
+                      type=pep440,pattern={{version}}
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v1
             - name: Set up Docker Buildx


### PR DESCRIPTION
Should also prevent pre-releases from being tagged as latest.