### PR TITLE
Roll-back to base image that does not require a PGSQL migration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aiidateam/aiida-core:1.6.8
+FROM aiidateam/aiida-core:1.6.5-bionic
 
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,7 +1,7 @@
 # Dependencies for notebook server and interaction with JupyterHub
 jupyterhub==1.5.0
 jupyterlab==3.0.17
-notebook==6.4.12
+notebook==6.4.10
 # Detect notebooks written in MyST Markdown
 jupytext==1.13.4
 # Dependencies for jupyter widgets


### PR DESCRIPTION
This commit partially reverts #257.