### PR TITLE
Slightly revise the release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,10 @@ jobs:
                   images: |
                       name=ghcr.io/aiidalab/__template__
                   tags: |
-                      type=ref,event=pr
-                      type=ref,event=tag
                       type=edge
+                      type=ref,event=pr
+                      type=raw,value={{tag}},enable=${{ github.ref_type == 'tag' && ! startsWith(github.ref_name, 'v') }}
+                      type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1
             - name: Generate docker-bake meta file.
               env:
                   BAKE_TEMPLATE_META: ${{ steps.meta.outputs.bake-file }}
@@ -141,9 +142,10 @@ jobs:
                   images: docker.io/aiidalab/${{ matrix.target }}
                   tags: |
                       type=edge
-                      type=ref,event=tag
-                      type=raw,value=aiida-${{ env.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag' }}
-                      type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' }}
+                      type=raw,value={{tag}},enable=${{ github.ref_type == 'tag' && ! startsWith(github.ref_name, 'v') }}
+                      type=raw,value=aiida-${{ env.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
+                      type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+                      type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1
             - name: Determine src image tag
               id: images
               run: |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Images are built for `linux/amd64` and `linux/arm64` during continuous integrati
 You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit up --registry=ghcr.io/ --version=pr-123`.
 Note: You may have to [log into the registry first](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
+### Creating a release
+
+To create a regular release, that means a release following the standard versionig scheme (2022.1001 and so on), use `bumpver`.
+For this, set up your development environment and then execute
+
+```console
+bumpver update
+```
+This will update the README.md file, make a commit, tag it, and then push it to the repository to kick-off the build and release flow.
+
 ## Deploy AiiDAlab with AiiDAlab Launch
 
 The `aiidalab-launch` tool provides a convenient and robust method of both launching and managing one or multiple AiiDAlab instances on your computer.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Image variants:
 
 Supported tags (released on [Docker Hub](https://hub.docker.com/r/aiidalab)):
 
-- `latest` – the latest tagged release
-- `$version` – the version of the a specific release (ex. `2022.1001`)
 - `edge` – the latest commit on the default branch
-- `aiida-$AIIDA_VERSION` – the _latest_ tagged commit with that AiiDA version (ex. `aiida-2.0.0`)
-- `python-$PYTHON_VERSION` – the _latest_ tagged commit with that Python version (ex. `python-3.9.2`)
+- `latest` – the latest _regular_ release
+- `aiida-$AIIDA_VERSION` – the _latest_ regular release with that AiiDA version (ex. `aiida-2.0.0`)
+- `python-$PYTHON_VERSION` – the _latest_ regular release with that Python version (ex. `python-3.9.2`)
+- `$version` – the version of a specific release (ex. `2022.1001`)
 
 In addition, `edge`, `latest`, and `$version` are also released _internally_ on the [GitHub Container registry (ghcr.io)](https://github.com/orgs/aiidalab/packages?ecosystem=container).
 Pull requests into the default branch are further released on ghcr.io wit the `pr-###` tag to simplify testing of development versions.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported tags (released on [Docker Hub](https://hub.docker.com/r/aiidalab)):
 - `$version` – the version of a specific release (ex. `2022.1001`)
 
 In addition, `edge`, `latest`, and `$version` are also released _internally_ on the [GitHub Container registry (ghcr.io)](https://github.com/orgs/aiidalab/packages?ecosystem=container).
-Pull requests into the default branch are further released on ghcr.io wit the `pr-###` tag to simplify testing of development versions.
+Pull requests into the default branch are further released on ghcr.io with the `pr-###` tag to simplify the testing of development versions.
 
 ## Quickstart
 
@@ -73,13 +73,13 @@ Note: You may have to [log into the registry first](https://docs.github.com/en/p
 
 ### Creating a release
 
-To create a regular release, that means a release following the standard versionig scheme (2022.1001 and so on), use `bumpver`.
+To create a regular release, that means a release following the standard versioning scheme (2022.1001 and so on), use `bumpver`.
 For this, set up your development environment and then execute
 
 ```console
 bumpver update
 ```
-This will update the README.md file, make a commit, tag it, and then push it to the repository to kick-off the build and release flow.
+This will update the README.md file, make a commit, tag it, and then push it to the repository to kick off the build and release flow.
 
 ## Deploy AiiDAlab with AiiDAlab Launch
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ Note: You may have to [log into the registry first](https://docs.github.com/en/p
 
 ### Creating a release
 
-To create a regular release, that means a release following the standard versioning scheme (2022.1001 and so on), use `bumpver`.
-For this, set up your development environment and then execute
-
+We distinguish between _regular_ releases and _special_ releases, where the former follow the standard versioning scheme (`v2022.1001`) and the latter would be specific to a certain use case, e.g., a workshop with dedicated requirements.
+To create a regular release, set up a development environment, and then use `bumpver`:
 ```console
 bumpver update
 ```
-This will update the README.md file, make a commit, tag it, and then push it to the repository to kick off the build and release flow.
+This will update the README.md file, make a commit, tag it, and then push both to the repository to kick off the build and release flow.
+
+To create a _special_ release, simply tag it with a tag name of your choice with the exception that it cannot start with the character `v`.
 
 ## Deploy AiiDAlab with AiiDAlab Launch
 

--- a/build.json
+++ b/build.json
@@ -1,8 +1,5 @@
 {
   "variable": {
-    "VERSION": {
-      "default": "2022.1001"
-    },
     "PYTHON_VERSION": {
       "default": "3.9.4"
     },

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,15 +1,12 @@
 [bumpver]
-current_version = "2022.1001"
-version_pattern = "YYYY.BUILD[-TAG]"
+current_version = "v2022.1001"
+version_pattern = "vYYYY.BUILD[-TAG]"
 commit_message = "Bump version {old_version} -> {new_version}."
 commit = true
 tag = true
-push = false
+push = true
 
 [bumpver.file_patterns]
 "bumpver.toml" = [
     'current_version = "{version}"'
-]
-"build.json" = [
-    '"default": "{version}"'
 ]


### PR DESCRIPTION
A regular release is one that follows the standard versioning scheme (2022.1001 and so on). Special releases, like 'aiida-tutorial-2022' will not be tagged with 'latest' or the 'aiida-' and 'python-' tags by default.

Add documentation for maintainers on how to create a release.