### PR TITLE
Remove AiiDA version defaults in Dockerfiles

### DIFF
--- a/stack/base-with-services/Dockerfile
+++ b/stack/base-with-services/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 USER root
 WORKDIR /opt/
 
-ARG AIIDA_VERSION=2.0.0
+ARG AIIDA_VERSION
 
 RUN mamba create -n aiida-core-services --yes \
      aiida-core.services=${AIIDA_VERSION} \

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 USER root
 WORKDIR /opt/
 
-ARG AIIDA_VERSION=2.0.0
+ARG AIIDA_VERSION
 
 # Install the shared requirements.
 COPY requirements.txt .


### PR DESCRIPTION
Since the AiiDA `core` version is obtained from the `build.json`,
these are just defaults that are rarely used. So at this point
the default are only a source of confusion and over-specification
and it is better to remove them.