### PR TITLE
aiida-core installed by pip and bump python version 3.10

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
   "variable": {
     "PYTHON_VERSION": {
-      "default": "3.9.4"
+      "default": "3.10.6"
     },
     "AIIDA_VERSION": {
       "default": "2.0.3"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "REGISTRY" {
 }
 
 variable "PLATFORMS" {
-  default = ["linux/amd64", "linux/arm64"]
+  default = ["linux/amd64"]
 }
 
 function "tags" {

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=jupyter/minimal-notebook:python-3.9.4
+ARG BASE=jupyter/minimal-notebook:python-3.10.6
 FROM ${BASE}
 
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
@@ -10,13 +10,10 @@ ARG AIIDA_VERSION
 
 # Install the shared requirements.
 COPY requirements.txt .
-RUN mamba install --yes \
-     aiida-core=${AIIDA_VERSION} \
-     --file requirements.txt \
-     && mamba clean --all -f -y && \
+RUN pip install --no-cache-dir aiida-core==${AIIDA_VERSION} \
+     -r requirements.txt && \
      fix-permissions "${CONDA_DIR}" && \
      fix-permissions "/home/${NB_USER}"
-
 
 # Pin shared requirements in the base environemnt.
 RUN cat requirements.txt | xargs -I{} conda config --system --add pinned_packages {}

--- a/stack/full-stack/Dockerfile
+++ b/stack/full-stack/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=base "${CONDA_DIR}/envs/aiida-core-services" "${CONDA_DIR}/envs/aiid
 COPY --from=base /usr/local/bin/before-notebook.d /usr/local/bin/before-notebook.d
 
 RUN fix-permissions "${CONDA_DIR}"
-RUN fix-permissions "/home/${NB_USER}/.aiida"
+RUN fix-permissions "/home/${NB_USER}"
 
 USER ${NB_USER}
 

--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -15,9 +15,7 @@ RUN apt-get update --yes && \
 
 # Install aiidalab package
 ARG AIIDALAB_VERSION=22.08.0
-RUN mamba install --yes \
-     aiidalab=${AIIDALAB_VERSION} \
-     && mamba clean --all -f -y && \
+RUN pip install --no-cache-dir aiidalab==${AIIDALAB_VERSION} && \
      fix-permissions "${CONDA_DIR}" && \
      fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
fixes #265 

I am more kin to using pip to install `aiida-core` which is more well-tested and has fewer restrictions when comes to conda dependencies (for example if we want to have `arm64` supported). 
The current blocker of using python3.10 is that the wrapt 1.11 does not have python3.10 support which addressed by https://github.com/aiidateam/aiida-core/pull/5698. It also shows that conda install of aiida-core is not well tested.