### PR TITLE
Using base image with python version 3.9.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For manual testing, you can start the images with `doit up`, however we recommen
 
 ### Continuous integration
 
-Images are built for `linux/amd64` and `linux/arm64` during continuous integration for all pull requests into the default branch and pushed to the GitHub Container Registry (ghcr.io) with tags `ghcr.io/aiidalab/*:pr-###`.
+Images are built for `linux/amd64` during continuous integration for all pull requests into the default branch and pushed to the GitHub Container Registry (ghcr.io) with tags `ghcr.io/aiidalab/*:pr-###`.
 You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit up --registry=ghcr.io/ --version=pr-123`.
 Note: You may have to [log into the registry first](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -21,7 +21,7 @@ variable "REGISTRY" {
 }
 
 variable "PLATFORMS" {
-  default = ["linux/amd64", "linux/arm64"]
+  default = ["linux/amd64"]
 }
 
 function "tags" {

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=jupyter/minimal-notebook:python-3.9.4
+ARG BASE=jupyter/minimal-notebook:python-3.9.13
 FROM ${BASE}
 
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"


### PR DESCRIPTION
As mentioned https://github.com/aiidalab/aiidalab-docker-stack/pull/316#issuecomment-1277911476,
The new base jupyter/minimal-notebook start to support linux/arm64/v8 which is not for the old base image. This is also the wired reason that the arm64 build pass and what is being downloaded in my arm64 machine is actually amd64.
I propose to remove the support to arm64 and add it back after I also start and test by using the self-hosted CI runner.