### PR TITLE
Fix: Add missing JUPYTER_CONFIG_PATH

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -52,6 +52,10 @@ if [ -f /opt/bin/load-singlesshagent.sh ]; then\n\
    . /opt/bin/load-singlesshagent.sh\n\
 fi\n' >> "/home/${NB_USER}/.bashrc"
 
+# Workaround for missing Jupyter config path,
+# needed for locally installed notebook extensions (e.g. nglview)
+ENV JUPYTER_CONFIG_PATH=/home/jovyan/.local/etc/jupyter
+
 USER ${NB_USER}
 
 WORKDIR "/home/${NB_USER}"


### PR DESCRIPTION
See this comment for details https://github.com/aiidalab/aiidalab/issues/322#issuecomment-1323417290

This perhaps should be fixed in the `jupyter/minimal-notebook` image itself, but in the meantime we fix it here.