### PR TITLE
Fix Python version in build.json

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
   "variable": {
     "PYTHON_VERSION": {
-      "default": "3.9.4"
+      "default": "3.9.13"
     },
     "AIIDA_VERSION": {
       "default": "2.1.2"


### PR DESCRIPTION
This was an omission in #318. The Python version specified in `build.json` is used to automatically generate the image tags on Dockerhub. So currently, for example the image `aiidalab/full-stack:python-9.4` actually corresponds to python-9.13

https://hub.docker.com/r/aiidalab/full-stack/tags

![image](https://user-images.githubusercontent.com/9539441/203619380-285851f5-68ee-4b1d-8016-6594cd568e3d.png)
