### PR TITLE
Using `notebook` CMD to run the jupyter stack

### DIFF
--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -3,11 +3,11 @@ FROM base
 
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 
-# The lab mode is default to run jupyter server.
-# Here the CMD pinned to `notebook` for running in legacy notebook backend
-# In the future, we have appmode compatible with nbclassic
-# we can use the server backend which is the alternative of legacy 
-# notebook backend.
+# By default, Jupyter Docker image launches the JupyterLab interface.
+# Here, we change it to the classic Jupyter Notebook which is used by AiiDAlab.
+# In the future, we might want to switch to other options such as `nbclassic` or `retro`, 
+# but the `nbclassic` is not supported because of appmode.
+# see: https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#switching-back-to-the-classic-notebook-or-using-a-different-startup-command
 ENV DOCKER_STACKS_JUPYTER_CMD=notebook
 
 USER root

--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 
 # By default, Jupyter Docker image launches the JupyterLab interface.
 # Here, we change it to the classic Jupyter Notebook which is used by AiiDAlab.
-# In the future, we might want to switch to other options such as `nbclassic` or `retro`, 
+# In the future, we might want to switch to other options such as `nbclassic` or `retro`,
 # but the `nbclassic` is not supported because of appmode.
 # see: https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#switching-back-to-the-classic-notebook-or-using-a-different-startup-command
 ENV DOCKER_STACKS_JUPYTER_CMD=notebook

--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -3,6 +3,13 @@ FROM base
 
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 
+# The lab mode is default to run jupyter server.
+# Here the CMD pinned to `notebook` for running in legacy notebook backend
+# In the future, we have appmode compatible with nbclassic
+# we can use the server backend which is the alternative of legacy 
+# notebook backend.
+ENV DOCKER_STACKS_JUPYTER_CMD=notebook
+
 USER root
 WORKDIR /opt/
 
@@ -74,9 +81,6 @@ WORKDIR "/home/${NB_USER}"
 
 RUN  mkdir -p /home/${NB_USER}/apps
 
-# Switch to NOTEBOOK_ARGS approach (see below)
-# for newer jupyter docker stack versions.
-RUN echo 'c.NotebookApp.default_url="/apps/apps/home/start.ipynb"' >> /etc/jupyter/jupyter_notebook_config.py
-# ENV NOTEBOOK_ARGS \
-     # "--NotebookApp.default_url='/apps/apps/home/start.ipynb'" \
-     # "--ContentsManager.allow_hidden=True"
+ENV NOTEBOOK_ARGS \
+     "--NotebookApp.default_url='/apps/apps/home/start.ipynb'" \
+     "--ContentsManager.allow_hidden=True"


### PR DESCRIPTION
The new `jupyter/minimal-notebook` image uses `lab` CMD to run the jupyter server, which was introduced by https://github.com/jupyter/docker-stacks/pull/1575. It provide `DOCKER_STACKS_JUPYTER_CMD` to set how to run it.
The lab (full-stack) is for AiiDAlab only and should start with notebook mode. I pin it as an environment variable to start the jupyter backend.
Since we have the new jupyterhub, the `NOTEBOOK_ARGS` can be used to set the notebook arguments.