### PR TITLE
Test AWB installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,31 @@ jobs:
               shell: bash -l {0}  # required to activate the conda environment
               env: ${{ fromJSON(needs.build.outputs.images) }}
               run: |
-                  pytest -v
+                  pytest -v -m "not integration"
+
+    integration-test:
+        needs: test
+
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Setup Python test environment
+              uses: mamba-org/provision-with-micromamba@v13
+              with:
+                  cache-env: true
+            - name: Run tests
+              shell: bash -l {0}  # required to activate the conda environment
+              env: ${{ fromJSON(needs.build.outputs.images) }}
+              run: |
+                  pytest -v -m integration
 
     release:
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
               run: pytest -v -m "not integration"
 
     integration-test:
+        needs: build
         runs-on: ubuntu-latest
         timeout-minutes: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,9 @@ jobs:
             - name: Run tests
               shell: bash -l {0}  # required to activate the conda environment
               env: ${{ fromJSON(needs.build.outputs.images) }}
-              run: |
-                  pytest -v -m "not integration"
+              run: pytest -v -m "not integration"
 
     integration-test:
-        needs: test
-
         runs-on: ubuntu-latest
         timeout-minutes: 10
 
@@ -126,11 +123,10 @@ jobs:
               uses: mamba-org/provision-with-micromamba@v13
               with:
                   cache-env: true
-            - name: Run tests
+            - name: Run integration tests
               shell: bash -l {0}  # required to activate the conda environment
               env: ${{ fromJSON(needs.build.outputs.images) }}
-              run: |
-                  pytest -v -m integration
+              run: pytest -v -m "integration"
 
     release:
         if: >-

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -131,6 +131,7 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     assert "dependency conflict" not in output
     assert f"Installed '{package_name}' version" in output
 
+    # Install pytest inside the container
     output = (
         aiidalab_exec(
             # f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
@@ -140,6 +141,19 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
         .decode()
         .strip()
     )
+    assert "ERROR" not in output
+
+    # Run AWB test suite
+    output = (
+        aiidalab_exec(
+            # f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
+            f"bash -c 'cd /home/{nb_user}/apps/{package_name} && pytest -v'",
+            user=nb_user,
+        )
+        .decode()
+        .strip()
+    )
+    assert "ERROR" not in output
 
 
 def test_path_local_pip(aiidalab_exec, nb_user):

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -70,27 +70,33 @@ def test_verdi_status(aiidalab_exec, nb_user):
     assert "Daemon is running" in output
 
 
+@pytest.mark.skip(reason="Last AWB stable release doesn't support AiiDA-2.0 yet")
 def test_install_widgets_base(aiidalab_exec, nb_user, variant):
     if "lab" not in variant:
         pytest.skip()
+    package_name = "aiidalab-widgets-base"
     output = (
-        aiidalab_exec("aiidalab install --yes aiidalab-widgets-base", user=nb_user)
+        aiidalab_exec(f"aiidalab install --yes {package_name}", user=nb_user)
         .decode()
         .strip()
     )
     assert "ERROR" not in output
     assert "dependency conflict" not in output
+    assert "Installed '{package_name}' version" in output
 
 
 def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     if "lab" not in variant:
         pytest.skip()
+    package_name = "aiidalab-widgets-base"
     output = (
         aiidalab_exec(
-            "aiidalab install --yes aiidalab-widgets-base@git+https://github.com/aiidalab/aiidalab-widgets-base.git",
+            "aiidalab install --yes {package_name}@git+https://github.com/aiidalab/{package_name}.git",
             user=nb_user,
         )
         .decode()
         .strip()
     )
-    assert output == ""
+    assert "ERROR" not in output
+    assert "dependency conflict" not in output
+    assert "Installed '{package_name}' version" in output

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -134,7 +134,7 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     output = (
         aiidalab_exec(
             # f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
-            f"bash -c 'cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
+            f"bash -c 'cd /home/{nb_user}/apps/{package_name} && pip install .[tests]'",
             user=nb_user,
         )
         .decode()

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -133,7 +133,8 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
 
     output = (
         aiidalab_exec(
-            f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
+            # f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
+            f"bash -c 'cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
             user=nb_user,
         )
         .decode()

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -131,6 +131,15 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     assert "dependency conflict" not in output
     assert f"Installed '{package_name}' version" in output
 
+    output = (
+        aiidalab_exec(
+            f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
+            user=nb_user,
+        )
+        .decode()
+        .strip()
+    )
+
 
 def test_path_local_pip(aiidalab_exec, nb_user):
     """test that the pip local bin path ~/.local/bin is added to PATH"""

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -100,11 +100,11 @@ def test_verdi_status(aiidalab_exec, nb_user):
     assert "Daemon is running" in output
 
 
+@pytest.mark.parametrize("package_name", ["aiidalab-widgets-base", "aiidalab-qe"])
 @pytest.mark.skip(reason="Last AWB stable release doesn't support AiiDA-2.0 yet")
-def test_install_widgets_base(aiidalab_exec, nb_user, variant):
+def test_install_apps_from_stable(aiidalab_exec, package_name, nb_user, variant):
     if "lab" not in variant:
         pytest.skip()
-    package_name = "aiidalab-widgets-base"
     output = (
         aiidalab_exec(f"aiidalab install --yes {package_name}", user=nb_user)
         .decode()
@@ -115,10 +115,10 @@ def test_install_widgets_base(aiidalab_exec, nb_user, variant):
     assert f"Installed '{package_name}' version" in output
 
 
-def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
+@pytest.mark.parametrize("package_name", ["aiidalab-widgets-base", "aiidalab-qe"])
+def test_install_apps_from_master(aiidalab_exec, package_name, nb_user, variant):
     if "lab" not in variant:
         pytest.skip()
-    package_name = "aiidalab-widgets-base"
     output = (
         aiidalab_exec(
             f"aiidalab install --yes {package_name}@git+https://github.com/aiidalab/{package_name}.git",
@@ -130,30 +130,6 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     assert "ERROR" not in output
     assert "dependency conflict" not in output
     assert f"Installed '{package_name}' version" in output
-
-    # Install pytest inside the container
-    output = (
-        aiidalab_exec(
-            # f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
-            f"bash -c 'cd /home/{nb_user}/apps/{package_name} && pip install .[tests]'",
-            user=nb_user,
-        )
-        .decode()
-        .strip()
-    )
-    assert "ERROR" not in output
-
-    # Run AWB test suite
-    output = (
-        aiidalab_exec(
-            # f"cd /home/{nb_user}/apps/{package_name} && pip install .[tests]",
-            f"bash -c 'cd /home/{nb_user}/apps/{package_name} && pytest -v'",
-            user=nb_user,
-        )
-        .decode()
-        .strip()
-    )
-    assert "ERROR" not in output
 
 
 def test_path_local_pip(aiidalab_exec, nb_user):

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -68,3 +68,29 @@ def test_verdi_status(aiidalab_exec, nb_user):
     output = aiidalab_exec("verdi status", user=nb_user).decode().strip()
     assert "Connected to RabbitMQ" in output
     assert "Daemon is running" in output
+
+
+def test_install_widgets_base(aiidalab_exec, nb_user, variant):
+    if "lab" not in variant:
+        pytest.skip()
+    output = (
+        aiidalab_exec("aiidalab install --yes aiidalab-widgets-base", user=nb_user)
+        .decode()
+        .strip()
+    )
+    assert "ERROR" not in output
+    assert "dependency conflict" not in output
+
+
+def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
+    if "lab" not in variant:
+        pytest.skip()
+    output = (
+        aiidalab_exec(
+            "aiidalab install --yes aiidalab-widgets-base@git+https://github.com/aiidalab/aiidalab-widgets-base.git",
+            user=nb_user,
+        )
+        .decode()
+        .strip()
+    )
+    assert output == ""

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -100,6 +100,7 @@ def test_verdi_status(aiidalab_exec, nb_user):
     assert "Daemon is running" in output
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("package_name", ["aiidalab-widgets-base", "aiidalab-qe"])
 @pytest.mark.skip(reason="Last AWB stable release doesn't support AiiDA-2.0 yet")
 def test_install_apps_from_stable(aiidalab_exec, package_name, nb_user, variant):
@@ -115,7 +116,8 @@ def test_install_apps_from_stable(aiidalab_exec, package_name, nb_user, variant)
     assert f"Installed '{package_name}' version" in output
 
 
-@pytest.mark.parametrize("package_name", ["aiidalab-widgets-base", "aiidalab-qe"])
+@pytest.mark.integration
+@pytest.mark.parametrize("package_name", ["aiidalab-widgets-base"])
 def test_install_apps_from_master(aiidalab_exec, package_name, nb_user, variant):
     if "lab" not in variant:
         pytest.skip()

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -112,7 +112,7 @@ def test_install_widgets_base(aiidalab_exec, nb_user, variant):
     )
     assert "ERROR" not in output
     assert "dependency conflict" not in output
-    assert "Installed '{package_name}' version" in output
+    assert f"Installed '{package_name}' version" in output
 
 
 def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
@@ -121,7 +121,7 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     package_name = "aiidalab-widgets-base"
     output = (
         aiidalab_exec(
-            "aiidalab install --yes {package_name}@git+https://github.com/aiidalab/{package_name}.git",
+            f"aiidalab install --yes {package_name}@git+https://github.com/aiidalab/{package_name}.git",
             user=nb_user,
         )
         .decode()
@@ -129,7 +129,7 @@ def test_install_widgets_base_master(aiidalab_exec, nb_user, variant):
     )
     assert "ERROR" not in output
     assert "dependency conflict" not in output
-    assert "Installed '{package_name}' version" in output
+    assert f"Installed '{package_name}' version" in output
 
 
 def test_path_local_pip(aiidalab_exec, nb_user):


### PR DESCRIPTION
Basic smoke tests to ensure we can install AWB and QeApp in the image. This is useful to identify conflicting dependencies downstream.