### PR TITLE
Add gcc compiler in base stack

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -7,7 +7,7 @@ USER root
 
 RUN apt-get update --yes && \
     apt-get install --yes --no-install-recommends \
-    # for apps which need to install pymatgen: 
+    # for apps which need to install pymatgen:
     # https://pymatgen.org/installation.html#installation-tips-for-optional-libraries
     build-essential && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -4,6 +4,14 @@ FROM ${BASE}
 LABEL maintainer="AiiDAlab Team <aiidalab@materialscloud.org>"
 
 USER root
+
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    # for apps which need to install pymatgen: 
+    # https://pymatgen.org/installation.html#installation-tips-for-optional-libraries
+    build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/
 
 ARG AIIDA_VERSION

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -117,7 +117,7 @@ def test_install_apps_from_stable(aiidalab_exec, package_name, nb_user, variant)
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("package_name", ["aiidalab-widgets-base"])
+@pytest.mark.parametrize("package_name", ["aiidalab-widgets-base", "aiidalab-qe"])
 def test_install_apps_from_master(aiidalab_exec, package_name, nb_user, variant):
     if "lab" not in variant:
         pytest.skip()


### PR DESCRIPTION
The gcc is installed in`build-essential` by apt. The size of `full-stack` increased from 2.22GB to 2.43GB which is half the size it installed by conda. 
I also test with installing the pymatgen and all went will.