### PR TITLE
Install povray

### DIFF
--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -16,7 +16,8 @@ WORKDIR /opt/
 # Install additional system packages
 RUN apt-get update --yes && \
      apt-get install --yes --no-install-recommends \
-     curl povray \
+     curl \
+     povray \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 

--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /opt/
 # Install additional system packages
 RUN apt-get update --yes && \
      apt-get install --yes --no-install-recommends \
-     curl \
+     curl povray \
      && apt-get clean \
      && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Povray is needed by AWB to render molecular images. Currently the render button in the Download tab of StructureViewer is broken because of this missing dependency. povray must be installed by apt, so needs to be installed in the image.

CC @unkcpz 