### PR TITLE
Bump aiida-core version to 2.2.1

### DIFF
--- a/build.json
+++ b/build.json
@@ -4,7 +4,7 @@
       "default": "3.9.13"
     },
     "AIIDA_VERSION": {
-      "default": "2.1.2"
+      "default": "2.2.1"
     },
     "AIIDALAB_VERSION": {
       "default": "22.11.0"


### PR DESCRIPTION
New version of aiida-core has been released today, with a couple of important bugfixes (one of them I might need for my App, not sure). Among others it also has updated pymatgen dependency that should prevent some of the issues we've had, as described in #320.