### PR TITLE
New conda environments in ~/.conda/ by default

### DIFF
--- a/stack/base-with-services/Dockerfile
+++ b/stack/base-with-services/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/
 
 ARG AIIDA_VERSION
 
-RUN mamba create -n aiida-core-services --yes \
+RUN mamba create -p /opt/conda/envs/aiida-core-services --yes \
      aiida-core.services=${AIIDA_VERSION} \
      rabbitmq-server=3.8.14 \
      && mamba clean --all -f -y && \

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -63,6 +63,13 @@ fi\n' >> "/home/${NB_USER}/.bashrc"
 # Add ~/.local/bin to PATH where the dependencies get installed via pip
 ENV PATH=${PATH}:/home/${NB_USER}/.local/bin
 
+# Add conda envs_dirs in home directory,
+# which will persist between container invocation
+# NOTE: The order here is important!
+# We want conda to create environments in ~/.conda/ by default
+RUN conda config --system --add envs_dirs /opt/conda
+RUN conda config --system --add envs_dirs "~/.conda/envs"
+
 USER ${NB_USER}
 
 WORKDIR "/home/${NB_USER}"

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -23,6 +23,9 @@ def test_aiidalab_available(aiidalab_exec, nb_user, variant):
 def test_create_conda_environment(aiidalab_exec, nb_user):
     output = aiidalab_exec("conda create -y -n tmp", user=nb_user).decode().strip()
     assert "conda activate tmp" in output
+    # New conda environments should be created in ~/.conda/envs/
+    output = aiidalab_exec("conda env list", user=nb_user).decode().strip()
+    assert f"/home/{nb_user}/.conda/envs/tmp" in output
 
 
 def test_correct_python_version_installed(aiidalab_exec, python_version):


### PR DESCRIPTION
In the current image, when a user creates a new conda environment with `conda create --name new-env`, it will be created in `/opt/conda/envs`, but that's no good since it will not be persisted between container invocation. 

In the QeApp, this is solved by specifying the full path to the environment like this:

```sh
conda create -p ~/.conda/envs/quantum-espresso
```

https://github.com/aiidalab/aiidalab-qe/blob/d6b6d046d42b186be60bbd34ca8d001a3fc4060a/aiidalab_qe/setup_codes.py#L44
But the disadvantage is that to activate this environment, one needs to provide the full path as well, which is clumsy.

In this PR I modify the conda config so that the new environments are created in `~/.conda/envs/` by default.
This change actually makes the behavior consistent with the old docker stack image, so it should make migration easier for AiiDAlab app developers.

Closes #352