### PR TITLE
Configure custom pytest marker for integration tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# https://docs.pytest.org/en/stable/how-to/mark.html#raising-errors-on-unknown-marks
+addopts = --strict-markers
+markers =
+  integration: testing installation of AiiDAlab apps (deselect with '-m "not integration"')


### PR DESCRIPTION
We're using a custom `integration` pytest marker for tests where we check that we can successfully install AWB and QeApp into the image. We run these tests in a separate workflow by running `pytest -m "integration"`, while the main test suite is invoked with `pytest -m "not integration"`.

Pytest currently emits a warning because it doesn't recognize this custom marker, as you can see in the GHA logs, e.g. here https://github.com/aiidalab/aiidalab-docker-stack/actions/runs/3751530007/jobs/6372705737

```python
PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?
You can register custom marks to avoid this warning - for details, see 
https://docs.pytest.org/en/stable/how-to/mark.html
```

Here are the different ways to address this:

1. Do nothing (the current approach on main)
2. Silence the warning, using a CLI option: `pytest -W ignore::_pytest.warning_types.PytestUnknownMarkWarning`
3. Use the `pytest_configure` hook in `conftest` file, as described here https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks
4. Define the markers explicitly in a new `pytest.ini` file. (this PR) Since this is not a Python repo, we couldn't reuse an existing `setup.cfg` or `pyproject.toml` for this, hence we need an extra config file. :-( In this PR, I also configured pytest to error out if an unknown marker is found in the future, as opposed to only emitting a warning.

I think it is better to be explicit about this, so I'd go with either option 3 or 4. I don't have a strong preference, option 4 seems more sustainable in case we need to do further configuration in the future (with the disadvantage of having an extra file.