### PR TITLE
Fix .vimrc placement

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -66,9 +66,3 @@ ENV PATH=${PATH}:/home/${NB_USER}/.local/bin
 USER ${NB_USER}
 
 WORKDIR "/home/${NB_USER}"
-
-# The vim.tiny shipped with jupyter base stack start vim
-# in compatible mode, by creating `.vimrm` file in user home
-# make it nocompatible mode so the modern vim features is available:
-# https://superuser.com/questions/543317/what-is-compatible-mode-in-vim/543327#543327
-RUN touch .vimrc

--- a/stack/base/before-notebook.d/10_setup-ssh.sh
+++ b/stack/base/before-notebook.d/10_setup-ssh.sh
@@ -13,3 +13,10 @@ fi
 
 # Start the ssh-agent.
 eval `ssh-agent`
+
+# The vim.tiny shipped with jupyter base stack start vim
+# in a so called compatible mode. Let's turn it off to make modern vim features available.
+# https://superuser.com/questions/543317/what-is-compatible-mode-in-vim/543327#543327
+if [[ ! -f /home/$NB_USER/.vimrc ]];then
+  echo "set nocp" > /home/${NB_USER}/.vimrc
+fi


### PR DESCRIPTION
We cannot create the `.vimrc` file in the Dockerfile, because the home folder gets mounted. We need to create it on startup.