### PR TITLE
Pin major PostgreSQL version in the image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
                       type=raw,value={{tag}},enable=${{ github.ref_type == 'tag' && ! startsWith(github.ref_name, 'v') }}
                       type=raw,value=aiida-${{ env.AIIDA_VERSION }},enable=${{ github.ref_type == 'tag'  && startsWith(github.ref_name, 'v') }}
                       type=raw,value=python-${{ env.PYTHON_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+                      type=raw,value=postgresql-${{ env.PGSQL_VERSION }},enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
                       type=match,pattern=v(\d{4}\.\d{4}(-.+)?),group=1
             - name: Determine src image tag
               id: images

--- a/build.json
+++ b/build.json
@@ -3,6 +3,9 @@
     "PYTHON_VERSION": {
       "default": "3.9.13"
     },
+    "PGSQL_VERSION": {
+      "default": "15"
+    },
     "AIIDA_VERSION": {
       "default": "2.2.1"
     },

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,9 @@ variable "VERSION" {
 variable "PYTHON_VERSION" {
 }
 
+variable "PGSQL_VERSION" {
+}
+
 variable "AIIDA_VERSION" {
 }
 
@@ -35,6 +38,7 @@ function "tags" {
   result = [
     "${REGISTRY}${ORGANIZATION}/${image}:${VERSION}",
     "${REGISTRY}${ORGANIZATION}/${image}:python-${PYTHON_VERSION}",
+    "${REGISTRY}${ORGANIZATION}/${image}:postgresql-${PGSQL_VERSION}",
     "${REGISTRY}${ORGANIZATION}/${image}:aiida-${AIIDA_VERSION}",
   ]
 }
@@ -75,6 +79,7 @@ target "base-with-services" {
   platforms = "${PLATFORMS}"
   args = {
     "AIIDA_VERSION" = "${AIIDA_VERSION}"
+    "PGSQL_VERSION" = "${PGSQL_VERSION}"
   }
 }
 target "lab" {

--- a/stack/base-with-services/Dockerfile
+++ b/stack/base-with-services/Dockerfile
@@ -7,9 +7,11 @@ USER root
 WORKDIR /opt/
 
 ARG AIIDA_VERSION
+ARG PGSQL_VERSION
 
 RUN mamba create -p /opt/conda/envs/aiida-core-services --yes \
      aiida-core.services=${AIIDA_VERSION} \
+     postgresql=${PGSQL_VERSION} \
      rabbitmq-server=3.8.14 \
      && mamba clean --all -f -y && \
      fix-permissions "${CONDA_DIR}" && \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,11 @@ def python_version(_build_config):
 
 
 @pytest.fixture(scope="session")
+def pgsql_version(_build_config):
+    return _build_config["PGSQL_VERSION"]["default"]
+
+
+@pytest.fixture(scope="session")
 def aiida_version(_build_config):
     return _build_config["AIIDA_VERSION"]["default"]
 

--- a/tests/test_aiidalab.py
+++ b/tests/test_aiidalab.py
@@ -34,6 +34,18 @@ def test_correct_python_version_installed(aiidalab_exec, python_version):
     assert parse(info["version"]) == parse(python_version)
 
 
+def test_correct_pgsql_version_installed(aiidalab_exec, pgsql_version, variant):
+    if "lab" in variant:
+        pytest.skip()
+    info = json.loads(
+        aiidalab_exec(
+            "mamba list -n aiida-core-services --json --full-name postgresql"
+        ).decode()
+    )[0]
+    assert info["name"] == "postgresql"
+    assert parse(info["version"]).major == parse(pgsql_version).major
+
+
 def test_correct_aiida_version_installed(aiidalab_exec, aiida_version):
     info = json.loads(
         aiidalab_exec("mamba list --json --full-name aiida-core").decode()


### PR DESCRIPTION
Pinning major PostgreSQL version in the Docker stack, as discussed in #355. I am not pinning minor version, since minor version updates shouldn't require DB migration.

I am also adding the `postgresql-{version}` docker tag to stable releases, in the same way we tag the images with Python and AiiDA versions. That should make it easy for users to avoid migrations if they need to.

Closes #355 