### PR TITLE
Add BASH completion functionality

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -20,6 +20,7 @@ ARG AIIDA_VERSION
 COPY requirements.txt .
 RUN mamba install --yes \
      aiida-core=${AIIDA_VERSION} \
+     mamba-bash-completion \
      --file requirements.txt \
      && mamba clean --all -f -y && \
      fix-permissions "${CONDA_DIR}" && \


### PR DESCRIPTION
As an alternative, we could install `bash-completion` package via APT, but using `mamba-bash-completion` from conda-forge makes it work for conda/mamba commands as well so I think it is preferable.

Closes #358 

Tested locally (image `ghcr.io/aiidalab/full-stack:pr-359`)