### PR TITLE
Bump aiida-core to v2.2.2

### DIFF
--- a/build.json
+++ b/build.json
@@ -7,7 +7,7 @@
       "default": "15"
     },
     "AIIDA_VERSION": {
-      "default": "2.2.1"
+      "default": "2.2.2"
     },
     "AIIDALAB_VERSION": {
       "default": "22.11.0"


### PR DESCRIPTION
Version 2.2.2 contains a critical bugfix for the AiiDA daemon. 

https://github.com/aiidateam/aiida-core/blob/main/CHANGELOG.md#v222---2023-02-10

We should include this in the next release (together with the aiidalab updates.