### PR TITLE
Provide mlocate for running unit tests in container

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update --yes && \
     # for apps which need to install pymatgen:
     # https://pymatgen.org/installation.html#installation-tips-for-optional-libraries
     build-essential && \
+    mlocate && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/


### PR DESCRIPTION
I think we'd better have this installed pre-hand, so users can run unit tests if they want even on the remote deployment, otherwise has to install it manually as root.