### PR TITLE
Disable release CI action when push to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -216,4 +216,4 @@ jobs:
               uses: softprops/action-gh-release@v1
               with:
                   generate_release_notes: true
-              if: github.repository == 'aiidalab/aiidalab-docker-stack' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+              if: github.repository == 'aiidalab/aiidalab-docker-stack' && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
This is a small change needed to not trigger release action when PR merged to `main`. It will anyway fail in the last step if the action is not from `v*` tag thus didn't cause any big issues but just a failed test in the `main` branch.