### PR TITLE
Pinning pyyaml<=5.3.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ pytest-docker
 docker-compose
 doit
 dunamai
+pyyaml<=5.3.1


### PR DESCRIPTION
A particular issue is caused by a new release of Cython which breaks PyYAML builds.
https://github.com/yaml/pyyaml/issues/724