### PR TITLE
Docker: Set Rabbitmq consumer_timeout to undefined

### DIFF
--- a/stack/base-with-services/before-notebook.d/30_start-rabbitmq-arm64.sh
+++ b/stack/base-with-services/before-notebook.d/30_start-rabbitmq-arm64.sh
@@ -19,8 +19,15 @@ echo LOG_BASE="${RABBITMQ_DATA_DIR}/log" >> "${RMQ_ETC_DIR}/rabbitmq-env.conf"
 # RabbitMQ with versions >= 3.8.15 have reduced some default timeouts
 # baseimage phusion/baseimage:jammy-1.0.0 running ubuntu 22.04 will install higher version of rabbimq by apt.
 # using workaround from https://github.com/aiidateam/aiida-core/wiki/RabbitMQ-version-to-use
-# set timeout to 100 hours
-echo "consumer_timeout=3600000" >> "${RMQ_ETC_DIR}/rabbitmq.conf"
+# setting the consumer_timeout to undefined disables the timeout
+cat > "${RMQ_ETC_DIR}/advanced.config" <<EOF
+%% advanced.config
+[
+  {rabbit, [
+    {consumer_timeout, undefined}
+  ]}
+].
+EOF
 
 # Explicitly define the node name. This is necessary because the mnesia subdirectory contains the hostname, which by
 # default is set to the value of $(hostname -s), which for docker containers, will be a random hexadecimal string. Upon


### PR DESCRIPTION
This fixes https://aiida.discourse.group/t/workchain-except/152/36 