### PR TITLE
Downgrade artifact-upload to fix arm64 build?

### DIFF
--- a/.github/actions/create-dev-env/action.yml
+++ b/.github/actions/create-dev-env/action.yml
@@ -18,7 +18,7 @@ runs:
           if: ${{ inputs.architecture == 'amd64' }}
           uses: actions/setup-python@v4
           with:
-              python-version: 3.x
+              python-version: 3.11
 
         - name: Install Dev Dependencies 📦
           run: |

--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -16,7 +16,7 @@ runs:
     using: composite
     steps:
         - name: Download built image 📥
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@v3
           with:
               name: ${{ inputs.image }}-${{ inputs.architecture }}
               path: /tmp/aiidalab

--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -16,7 +16,7 @@ runs:
     using: composite
     steps:
         - name: Download built image 📥
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
               name: ${{ inputs.image }}-${{ inputs.architecture }}
               path: /tmp/aiidalab

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -68,4 +68,6 @@ jobs:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar
                   retention-days: 3
+                  compression-level: 0
+                  if-no-files-found: error
               if: always()

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -68,6 +68,6 @@ jobs:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar
                   retention-days: 3
-                  compression-level: 0
+                  compression-level: 1
                   if-no-files-found: error
               if: always()

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -68,6 +68,6 @@ jobs:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar
                   retention-days: 3
-                  compression-level: 1
+                  compression-level: 0
                   if-no-files-found: error
               if: always()

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
@@ -63,7 +63,7 @@ jobs:
               if: always()
 
             - name: Upload image as artifact 💾
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -63,11 +63,10 @@ jobs:
               if: always()
 
             - name: Upload image as artifact 💾
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               with:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar
                   retention-days: 3
-                  compression-level: 0
                   if-no-files-found: error
               if: always()

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -25,19 +25,19 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
                   architecture: amd64
 
             - name: Download amd64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-amd64-tags
                   path: /tmp/aiidalab
             - name: Download arm64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-arm64-tags
                   path: /tmp/aiidalab

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -31,7 +31,7 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
@@ -87,7 +87,7 @@ jobs:
               shell: bash
 
             - name: Upload tags file 📤
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-${{ inputs.architecture }}-tags
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}-tags.txt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -213,7 +213,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: [merge-tags-ghcr, merge-tags-dockerhub]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Create release
               uses: softprops/action-gh-release@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,53 +3,13 @@ name: Build, test and push Docker Images
 
 on:
     pull_request:
-        paths:
-            - ".github/workflows/docker.yml"
-            # We use local reusable workflows to make architecture clean an simple
-            # https://docs.github.com/en/actions/using-workflows/reusing-workflows
-            - ".github/workflows/docker-build-test-upload.yml"
-            - ".github/workflows/docker-merge-tags.yml"
-            - ".github/workflows/docker-push.yml"
-
-            # We use local composite actions to combine multiple workflow steps within one action
-            # https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions
-            - ".github/actions/create-dev-env/action.yml"
-            - ".github/actions/load-image/action.yml"
-
-            - "stack/base/**"
-            - "stack/base-with-services/**"
-            - "stack/lab/**"
-            - "stack/full-stack/**"
-            - "build.json"
-            - "docker-bake.hcl"
-            - "tests/**"
-            - "requirements-dev.txt"
+        paths-ignore:
+            - "**.md"
     push:
         branches:
             - main
         tags:
             - "v*"
-        paths:
-            - ".github/workflows/docker.yml"
-            # We use local reusable workflows to make architecture clean an simple
-            # https://docs.github.com/en/actions/using-workflows/reusing-workflows
-            - ".github/workflows/docker-build-test-upload.yml"
-            - ".github/workflows/docker-merge-tags.yml"
-            - ".github/workflows/docker-push.yml"
-
-            # We use local composite actions to combine multiple workflow steps within one action
-            # https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions
-            - ".github/actions/create-dev-env/action.yml"
-            - ".github/actions/load-image/action.yml"
-
-            - "stack/base/**"
-            - "stack/base-with-services/**"
-            - "stack/lab/**"
-            - "stack/full-stack/**"
-            - "build.json"
-            - "docker-bake.hcl"
-            - "tests/**"
-            - "requirements-dev.txt"
     workflow_dispatch:
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,6 @@ name: Build, test and push Docker Images
 
 on:
     pull_request:
-        paths-ignore:
-            - "**.md"
     push:
         branches:
             - main


### PR DESCRIPTION
The arm64 build is failing on artifact-upload step. I am not sure if that is the consequence of the bump of `actions/artifact-upload` to v4, or something is wrong with our self-hosted runners. Let's see if downgrading helps.