### PR TITLE
Bump actions/artifact-upload to v4

### DIFF
--- a/.github/actions/create-dev-env/action.yml
+++ b/.github/actions/create-dev-env/action.yml
@@ -18,7 +18,7 @@ runs:
           if: ${{ inputs.architecture == 'amd64' }}
           uses: actions/setup-python@v4
           with:
-              python-version: 3.x
+              python-version: 3.11
 
         - name: Install Dev Dependencies 📦
           run: |

--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -16,7 +16,7 @@ runs:
     using: composite
     steps:
         - name: Download built image 📥
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
               name: ${{ inputs.image }}-${{ inputs.architecture }}
               path: /tmp/aiidalab

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -23,6 +23,7 @@ on:
 jobs:
     build-test-upload:
         runs-on: ${{ inputs.runsOn }}
+        timeout-minutes: 20
 
         steps:
             - name: Checkout Repo ⚡️

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -69,6 +69,5 @@ jobs:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar
                   retention-days: 3
-                  compression-level: 0
                   if-no-files-found: error
               if: always()

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
@@ -63,9 +63,11 @@ jobs:
               if: always()
 
             - name: Upload image as artifact 💾
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar
                   retention-days: 3
+                  compression-level: 0
+                  if-no-files-found: error
               if: always()

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -25,19 +25,19 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
                   architecture: amd64
 
             - name: Download amd64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-amd64-tags
                   path: /tmp/aiidalab
             - name: Download arm64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-arm64-tags
                   path: /tmp/aiidalab

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -31,7 +31,7 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
@@ -87,7 +87,7 @@ jobs:
               shell: bash
 
             - name: Upload tags file 📤
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-${{ inputs.architecture }}-tags
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}-tags.txt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,53 +3,11 @@ name: Build, test and push Docker Images
 
 on:
     pull_request:
-        paths:
-            - ".github/workflows/docker.yml"
-            # We use local reusable workflows to make architecture clean an simple
-            # https://docs.github.com/en/actions/using-workflows/reusing-workflows
-            - ".github/workflows/docker-build-test-upload.yml"
-            - ".github/workflows/docker-merge-tags.yml"
-            - ".github/workflows/docker-push.yml"
-
-            # We use local composite actions to combine multiple workflow steps within one action
-            # https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions
-            - ".github/actions/create-dev-env/action.yml"
-            - ".github/actions/load-image/action.yml"
-
-            - "stack/base/**"
-            - "stack/base-with-services/**"
-            - "stack/lab/**"
-            - "stack/full-stack/**"
-            - "build.json"
-            - "docker-bake.hcl"
-            - "tests/**"
-            - "requirements-dev.txt"
     push:
         branches:
             - main
         tags:
             - "v*"
-        paths:
-            - ".github/workflows/docker.yml"
-            # We use local reusable workflows to make architecture clean an simple
-            # https://docs.github.com/en/actions/using-workflows/reusing-workflows
-            - ".github/workflows/docker-build-test-upload.yml"
-            - ".github/workflows/docker-merge-tags.yml"
-            - ".github/workflows/docker-push.yml"
-
-            # We use local composite actions to combine multiple workflow steps within one action
-            # https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions
-            - ".github/actions/create-dev-env/action.yml"
-            - ".github/actions/load-image/action.yml"
-
-            - "stack/base/**"
-            - "stack/base-with-services/**"
-            - "stack/lab/**"
-            - "stack/full-stack/**"
-            - "build.json"
-            - "docker-bake.hcl"
-            - "tests/**"
-            - "requirements-dev.txt"
     workflow_dispatch:
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -213,7 +171,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: [merge-tags-ghcr, merge-tags-dockerhub]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Create release
               uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This is a revert amendment of https://github.com/aiidalab/aiidalab-docker-stack/pull/419 which merged improperly with test commints.

- The changes should significantly speed up artifact upload, see https://github.com/actions/upload-artifact#v4---whats-new
- Also include the updates of `action/checkout` action to v4
- include fix the python version of running environment to `3.11`.
- include the changes of removing paths change detection in `docker.yml`