### PR TITLE
Reduce arm usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
                   set: |
                       *.platform=${{ inputs.platforms }}
                       *.output=type=registry,push-by-digest=true,name-canonical=true
+                      *.cache-to=type=gha,scope=${{ github.workflow }},mode=max
+                      *.cache-from=type=gha,scope=${{ github.workflow }}
                   files: |
                       docker-bake.hcl
                       build.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,14 @@ name: Docker
 
 on:
     pull_request:
+        paths-ignore:
+            - "**.md"
+            - ruff.toml
+            - bumpver.toml
+            - .pre-commit-config.yaml
+            # We use doit only for local builds
+            - dodo.py
+            - aarch64-runner/**
     push:
         branches:
             - main
@@ -62,6 +70,7 @@ jobs:
             integration: false
 
     test-integration:
+        name: Integration tests
         needs: build
         strategy:
             fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,14 +62,19 @@ jobs:
             integration: false
 
     test-integration:
-        if: >-
-            startsWith(matrix.runner, 'ubuntu')
-            || github.ref_type == 'tag' || github.ref_name == 'main'
         needs: build
         strategy:
             fail-fast: false
+            # Trick to exclude arm64 tests from PRs
+            # https://github.com/orgs/community/discussions/26253
             matrix:
                 runner: [ubuntu-22.04, buildjet-4vcpu-ubuntu-2204-arm]
+                isPR:
+                    - ${{ github.event_name == 'pull_request' }}
+                exclude:
+                    - isPR: true
+                      runner: buildjet-4vcpu-ubuntu-2204-arm
+
         uses: ./.github/workflows/test.yml
         with:
             runsOn: ${{ matrix.runner }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,12 @@ jobs:
             runsOn: ubuntu-22.04
             platforms: linux/amd64,linux/arm64
 
-    # To save self-hosted runner resources, we're only testing full-stack image
+    # To save arm64 runner resources, we run the tests only on main
+    # and only for full-stack image (same for integration tests below).
     test-arm64:
+        if: >-
+            github.repository == 'aiidalab/aiidalab-docker-stack'
+            && (github.ref_type == 'tag' || github.ref_name == 'main')
         needs: build
         uses: ./.github/workflows/test.yml
         with:
@@ -58,6 +62,9 @@ jobs:
             integration: false
 
     test-integration:
+        if: >-
+            startsWith(matrix.runner, 'ubuntu')
+            || github.ref_type == 'tag' || github.ref_name == 'main'
         needs: build
         strategy:
             fail-fast: false
@@ -71,7 +78,7 @@ jobs:
             integration: true
 
     publish-ghcr:
-        needs: [build, test-amd64, test-arm64]
+        needs: [build, test-amd64]
         uses: ./.github/workflows/publish.yml
         with:
             runsOn: ubuntu-22.04
@@ -83,7 +90,7 @@ jobs:
         if: >-
             github.repository == 'aiidalab/aiidalab-docker-stack'
             && (github.ref_type == 'tag' || github.ref_name == 'main')
-        needs: [build, publish-ghcr]
+        needs: [build, test-amd64, test-arm64, publish-ghcr]
         uses: ./.github/workflows/publish.yml
         with:
             runsOn: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The repository uses the [doit automation tool](https://pydoit.org/) to automate 
 To use this system, setup a build end testing environment and install the dependencies with:
 
 ```console
-pip install -r requirements-dev.txt
+pip install -r requirements.txt
 ```
 
 ### Build images locally
@@ -55,7 +55,7 @@ The build system will attempt to detect the local architecture and automatically
 All commands `build`, `tests`, and `up` will use the locally detected platform and use a version tag based on the state of the local git repository.
 However, you can also specify a custom platform or version with the `--platform` and `--version` parameters, example: `doit build --arch=arm64 --version=my-version`.
 
-You can specify target stacks to build with `--target`, example: `doit build --target base --target full-stack`.
+You can specify target image variants to build with `--target`, example: `doit build --target base --target lab`.
 
 ### Run automated tests
 
@@ -70,18 +70,14 @@ For manual testing, you can start the images with `doit up`, however we recommen
 
 Images are built for `linux/amd64` and `linux/arm64` during continuous integration for all pull requests into the default branch and pushed to the GitHub Container Registry (ghcr.io) with tags `ghcr.io/aiidalab/*:pr-###`.
 You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit up --registry=ghcr.io/ --version=pr-123`.
-Note: You may have to [log into the registry first](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ### Creating a release
 
-We distinguish between _regular_ releases and _special_ releases, where the former follow the standard versioning scheme (`v2022.1001`) and the latter would be specific to a certain use case, e.g., a workshop with dedicated requirements.
-To create a regular release, set up a development environment, and then use `bumpver`:
+We use a calendar versioning scheme (e.g. `v2022.1001`), and we automate the release with `bumpver`. To create a release, make sure your are on an up-to-date main branch and run:
 ```console
 bumpver update
 ```
-This will update the README.md file, make a commit, tag it, and then push both to the repository to kick off the build and release flow.
-
-To create a _special_ release, simply tag it with a tag name of your choice with the exception that it cannot start with the character `v`.
+This will update the version in bumpver.toml, make a commit, tag it, and then push both to the repository to kick off the build and release flow.
 
 ## Deploy AiiDAlab with aiidalab-launch
 


### PR DESCRIPTION
I am already out of my free credits on buildjet. Here I am changing the workflow so that the ARM tests only run on main branch. It's not ideal but currently that's the easiest way forward.
I also try to use caching, it seems to help a little bit, but not fully (e.g. the arm part of the build is not cached). We can try to tweak it in a follow up PR.