### PR TITLE
Fix doit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,5 +53,7 @@ jobs:
                   pip freeze
 
             - name: Run tests
-              run: pytest -m "${{ inputs.integration && 'integration' || 'not integration' }}" --target ${{inputs.target}}
+              run: |
+                  doit tests -t ${{ inputs.target }} \
+                      --pytest-opts '-m "${{ inputs.integration && 'integration' || 'not integration' }}"'
               env: ${{ fromJSON(inputs.images) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,5 @@ jobs:
                   pip freeze
 
             - name: Run tests
-              run: |
-                  doit tests -t ${{ inputs.target }} \
-                      --pytest-opts '-m "${{ inputs.integration && 'integration' || 'not integration' }}"'
+              run: pytest -m "${{ inputs.integration && 'integration' || 'not integration' }}" --target ${{inputs.target}}
               env: ${{ fromJSON(inputs.images) }}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The build system will attempt to detect the local architecture and automatically
 All commands `build`, `tests`, and `up` will use the locally detected platform and use a version tag based on the state of the local git repository.
 However, you can also specify a custom platform or version with the `--platform` and `--version` parameters, example: `doit build --arch=arm64 --version=my-version`.
 
-You can specify target image variants to build with `--target`, example: `doit build --target base --target lab`.
+By default, all image variants are build. You can specify a single target image variant to build with `-t/--target`, example: `doit build --target base`.
 
 ### Run automated tests
 
@@ -64,12 +64,12 @@ Then run the automated tests with `doit tests`.
 
 Tip: The [continuous integration](#continuous-integration) workflow will build, release (at `ghcr.io/aiidalab/*:pr-###`), and test images for all pull requests into the default branch.
 
-For manual testing, you can start the images with `doit up`, however we recommend to use [aiidalab-launch](#deploy-aiidalab-with-aiidalab-launch) to setup a production-ready local deployment.
+For manual testing, you can start the images with `doit up --target full-stack`, however we recommend to use [aiidalab-launch](#deploy-aiidalab-with-aiidalab-launch) to setup a production-ready local deployment.
 
 ### Continuous integration
 
 Images are built for `linux/amd64` and `linux/arm64` during continuous integration for all pull requests into the default branch and pushed to the GitHub Container Registry (ghcr.io) with tags `ghcr.io/aiidalab/*:pr-###`.
-You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit up --registry=ghcr.io/ --version=pr-123`.
+You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit up --registry=ghcr.io --version=pr-123`.
 
 ### Creating a release
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, all image variants are build. You can specify a single target image 
 ### Run automated tests
 
 To run tests, first build the images as described in the previous section.
-Then run the automated tests with `doit tests`.
+Then run the automated tests for a given image with `doit tests --target <base|base-with-services|lab|full-stack>`.
 
 Tip: The [continuous integration](#continuous-integration) workflow will build, release (at `ghcr.io/aiidalab/*:pr-###`), and test images for all pull requests into the default branch.
 
@@ -69,7 +69,7 @@ For manual testing, you can start the images with `doit up --target full-stack`,
 ### Continuous integration
 
 Images are built for `linux/amd64` and `linux/arm64` during continuous integration for all pull requests into the default branch and pushed to the GitHub Container Registry (ghcr.io) with tags `ghcr.io/aiidalab/*:pr-###`.
-You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit up --registry=ghcr.io --version=pr-123`.
+You can run automated or manual tests against those images by specifying the registry and version for both the `up` and `tests` commands, example: `doit tests --registry=ghcr.io/ --version=pr-123`.
 
 ### Creating a release
 

--- a/dodo.py
+++ b/dodo.py
@@ -117,7 +117,9 @@ def task_tests():
     # TODO: This currently does not work!
     # https://github.com/aiidalab/aiidalab-docker-stack/issues/451
     return {
-        "actions": ["REGISTRY=%(registry)s VERSION=:%(version)s pytest -v"],
+        "actions": [
+            "REGISTRY=%(registry)s VERSION=:%(version)s pytest -v --target %(target)s"
+        ],
         "params": [_REGISTRY_PARAM, _VERSION_PARAM, _TARGET_PARAM],
         "verbosity": 2,
     }

--- a/dodo.py
+++ b/dodo.py
@@ -33,7 +33,7 @@ _REGISTRY_PARAM = {
     "long": "registry",
     "type": str,
     "default": "",
-    "help": "Specify the docker image registry (without the trailing slash).",
+    "help": "Specify the docker image registry (including the trailing slash).",
 }
 
 _ORGANIZATION_PARAM = {
@@ -114,7 +114,7 @@ def task_build():
         platforms = [f"linux/{architecture}"]
         overrides = {
             "VERSION": f":{version}",
-            "REGISTRY": f"{registry}/",
+            "REGISTRY": registry,
             "ORGANIZATION": organization,
             "PLATFORMS": platforms,
         }
@@ -150,7 +150,7 @@ def task_tests():
     return {
         "actions": [
             target_required,
-            "AIIDALAB_PORT=%(port)i REGISTRY=%(registry)s/ VERSION=:%(version)s "
+            "AIIDALAB_PORT=%(port)i REGISTRY=%(registry)s VERSION=:%(version)s "
             "pytest -s --target %(target)s --compose-cmd='%(compose-command)s' %(pytest-opts)s",
         ],
         "params": [
@@ -177,7 +177,7 @@ def task_up():
     return {
         "actions": [
             target_required,
-            "AIIDALAB_PORT=%(port)i REGISTRY=%(registry)s/ VERSION=:%(version)s "
+            "AIIDALAB_PORT=%(port)i REGISTRY=%(registry)s VERSION=:%(version)s "
             "%(compose-command)s -f stack/docker-compose.%(target)s.yml up --detach",
         ],
         "params": [

--- a/stack/docker-compose.base-with-services.yml
+++ b/stack/docker-compose.base-with-services.yml
@@ -13,7 +13,7 @@ services:
         volumes:
             - aiidalab-home-folder:/home/jovyan
         ports:
-            - "0.0.0.0:${AIIDALAB_PORT:-}:8888"
+            - "0.0.0.0:${AIIDALAB_PORT:-8888}:8888"
 
 volumes:
     aiidalab-home-folder:

--- a/stack/docker-compose.base.yml
+++ b/stack/docker-compose.base.yml
@@ -4,7 +4,7 @@ version: '3.4'
 services:
 
     database:
-        image: postgres:12.3
+        image: docker.io/postgres:12.3
         environment:
             POSTGRES_USER: pguser
             POSTGRES_PASSWORD: password
@@ -17,7 +17,7 @@ services:
             retries: 10
 
     messaging:
-        image: rabbitmq:3.8.3-management
+        image: docker.io/rabbitmq:3.8.3-management
         environment:
             RABBITMQ_DEFAULT_USER: guest
             RABBITMQ_DEFAULT_PASS: guest
@@ -40,7 +40,7 @@ services:
             messaging:
                 condition: service_started
         ports:
-            - "0.0.0.0:${AIIDALAB_PORT:-}:8888"
+            - "0.0.0.0:${AIIDALAB_PORT:-8888}:8888"
 
 volumes:
     aiida-postgres-db:

--- a/stack/docker-compose.full-stack.yml
+++ b/stack/docker-compose.full-stack.yml
@@ -13,7 +13,7 @@ services:
         volumes:
             - aiidalab-home-folder:/home/jovyan
         ports:
-            - "0.0.0.0:${AIIDALAB_PORT:-}:8888"
+            - "0.0.0.0:${AIIDALAB_PORT:-8888}:8888"
 
 volumes:
     aiidalab-home-folder:

--- a/stack/docker-compose.lab.yml
+++ b/stack/docker-compose.lab.yml
@@ -4,7 +4,7 @@ version: '3.4'
 services:
 
     database:
-        image: postgres:12.3
+        image: docker.io/postgres:12.3
         environment:
             POSTGRES_USER: pguser
             POSTGRES_PASSWORD: password
@@ -17,7 +17,7 @@ services:
             retries: 10
 
     messaging:
-        image: rabbitmq:3.8.3-management
+        image: docker.io/rabbitmq:3.8.3-management
         environment:
             RABBITMQ_DEFAULT_USER: guest
             RABBITMQ_DEFAULT_PASS: guest
@@ -40,7 +40,7 @@ services:
             messaging:
                 condition: service_started
         ports:
-            - "0.0.0.0:${AIIDALAB_PORT:-}:8888"
+            - "0.0.0.0:${AIIDALAB_PORT:-8888}:8888"
 
 volumes:
     aiida-postgres-db:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,11 +32,23 @@ def pytest_addoption(parser):
         help="target (image name) of the docker-compose file to use.",
         type=target_checker,
     )
+    parser.addoption(
+        "--compose-cmd",
+        action="store",
+        required=False,
+        default="docker compose",
+        help="Specify custom docker compose command (e.g. 'podman-compose').",
+    )
 
 
 @pytest.fixture(scope="session")
 def target(pytestconfig):
     return pytestconfig.getoption("target")
+
+
+@pytest.fixture(scope="session")
+def docker_compose_command(pytestconfig) -> str:
+    return pytestconfig.getoption("compose_cmd")
 
 
 @pytest.fixture(scope="session")
@@ -76,9 +88,12 @@ def aiidalab_exec(notebook_service, docker_compose):
     return execute
 
 
-@pytest.fixture
-def nb_user(aiidalab_exec):
-    return aiidalab_exec("bash -c 'echo \"${NB_USER}\"'").strip()
+@pytest.fixture(scope="session")
+def nb_user():
+    # Let's make this simpler and return a constant value to speed up the tests,
+    # otherwise we'd need to execute the following command for every test.
+    # return aiidalab_exec("bash -c 'echo \"${NB_USER}\"'").strip()
+    return "jovyan"
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #451. You can now build images locally with e..g

```console
doit build
```

and then run tests as 

```console
doit tests -t full-stack
```

I've also made some tweaks to support podman (and podman-compose) via extra `--compose-cmd` arguments. I've also fixed the `doit up` and `doit down` commands, which now have to include the `-t/--target` argument.