### PR TITLE
DEMO server: Add support for light local hyperqueue scheduler

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -51,6 +51,22 @@ ENV PIP_CONSTRAINT /opt/requirements.txt
 # Ensure that pip installs packages to ~/.local by default
 ENV PIP_USER 1
 
+# XXX: find the proper place for hq and aiida-hq installation, here only for proof of concept
+
+# Install the hq use the latest version 0.19 that include a bugfix to not raise failed setup
+RUN wget -qO- https://github.com/It4innovations/hyperqueue/releases/download/v0.19.0/hq-v0.19.0-linux-x64.tar.gz | tar xvz -C /usr/local/bin
+
+# Install the aiida-hq.
+RUN git clone https://github.com/unkcpz/aiida-hyperqueue && \
+     cd aiida-hyperqueue && \
+     # TODO: change the branch name
+     git checkout fea/mem-allocation && \
+     pip install --no-user --quiet --no-cache-dir "./" && \
+     fix-permissions "./" && \
+     fix-permissions "${CONDA_DIR}" && \
+     fix-permissions "/home/${NB_USER}"
+
+
 # Enable verdi autocompletion.
 RUN mkdir -p "${CONDA_DIR}/etc/conda/activate.d" && \
      echo 'eval "$(_VERDI_COMPLETE=bash_source verdi)"' >> "${CONDA_DIR}/etc/conda/activate.d/activate_aiida_autocompletion.sh" && \

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -36,6 +36,8 @@ RUN echo "aiida-core==${AIIDA_VERSION}" > /opt/requirements.txt
 RUN mamba install --yes \
      aiida-core=${AIIDA_VERSION} \
      mamba-bash-completion \
+     # XXX: for test install QE here
+     qe=7.2 \
      --file /opt/requirements.txt \
      && mamba clean --all -f -y && \
      fix-permissions "${CONDA_DIR}" && \
@@ -62,10 +64,10 @@ RUN git clone https://github.com/unkcpz/aiida-hyperqueue && \
      # TODO: change the branch name
      git checkout fea/mem-allocation && \
      pip install --no-user --quiet --no-cache-dir "./" && \
+     pip install aiida-quantumespresso && \
      fix-permissions "./" && \
      fix-permissions "${CONDA_DIR}" && \
      fix-permissions "/home/${NB_USER}"
-
 
 # Enable verdi autocompletion.
 RUN mkdir -p "${CONDA_DIR}/etc/conda/activate.d" && \
@@ -89,6 +91,9 @@ ENV AIIDA_USER_INSTITUTION Khedivial
 # https://aiida.readthedocs.io/projects/aiida-core/en/v2.0.0/howto/ssh.html#starting-the-ssh-agent
 # The startup of this script is configured in the before-notebook.d/20_setup-ssh.sh file.
 COPY load-singlesshagent.sh /opt/bin/
+
+# XXX: Remove me after, I am for test
+COPY test_script.py /opt/
 
 # Add ~/.local/bin to PATH where the dependencies get installed via pip
 ENV PATH=${PATH}:/home/${NB_USER}/.local/bin

--- a/stack/base/before-notebook.d/25_start_hq.sh
+++ b/stack/base/before-notebook.d/25_start_hq.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Start hq server
+nohup hq server start 1>$HOME/.hq-stdout 2>$HOME/.hq-stderr &
+
+# Start two workers each worker has 2 CPUs, thus no matter how much resourse the machine has
+# Only 4 "faked" CPUs are available. Each worker can have 2_560 mb. The
+# XXX: This requires more discussion on:
+# 1. read the CPU/MEM from environment variable in k8s deployment (the variable not avial for docker container)
+# 2. if it is a good idea just give the 4 fake CPUs. (personally like this setup, for large computation it will anyway goes to the HPC.)
+mkdir .hq-server
+nohup hq worker start --cpus=2 --resource "mem=sum(2560)" --no-detect-resources &
+nohup hq worker start --cpus=2 --resource "mem=sum(2560)" --no-detect-resources &

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -74,7 +74,7 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
         --transport core.local                                          \
         --scheduler hyperqueue                                          \
         --work-dir /home/${NB_USER}/aiida_run/                          \
-        --mpirun-command "mpirun -np {num_cpus} --mem {memory_mb}"       \
+        --mpirun-command "mpirun -np {num_cpus}"       \
         --mpiprocs-per-machine ${LOCALHOST_MPI_PROCS_PER_MACHINE} &&    \
     verdi computer configure core.local "${computer_name}"              \
         --non-interactive                                               \

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -61,6 +61,24 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
     verdi computer configure core.local "${computer_name}" \
         --non-interactive                                               \
         --safe-interval 0.0
+
+
+    # Setup localhost with hq as scheduler
+    computer_name=localhost-hq
+
+    verdi computer show ${computer_name} || verdi computer setup \
+        --non-interactive                                               \
+        --label "${computer_name}"                                      \
+        --description "this computer"                                   \
+        --hostname "localhost"                                          \
+        --transport core.local                                          \
+        --scheduler hyperqueue                                          \
+        --work-dir /home/${NB_USER}/aiida_run/                          \
+        --mpirun-command "mpirun -np {num_cpus} --mem {memory_mb}"       \
+        --mpiprocs-per-machine ${LOCALHOST_MPI_PROCS_PER_MACHINE} &&    \
+    verdi computer configure core.local "${computer_name}"              \
+        --non-interactive                                               \
+        --safe-interval 5.0
 fi
 
 

--- a/stack/base/before-notebook.d/45_start_hq_setup_qe_blob.sh
+++ b/stack/base/before-notebook.d/45_start_hq_setup_qe_blob.sh
@@ -5,9 +5,24 @@ nohup hq server start 1>$HOME/.hq-stdout 2>$HOME/.hq-stderr &
 
 # Start two workers each worker has 2 CPUs, thus no matter how much resourse the machine has
 # Only 4 "faked" CPUs are available. Each worker can have 2_560 mb. The
+# The hyperthreading is turned off for the mpi job no matter if the computer has hyperthreading or not.
 # XXX: This requires more discussion on:
 # 1. read the CPU/MEM from environment variable in k8s deployment (the variable not avial for docker container)
 # 2. if it is a good idea just give the 4 fake CPUs. (personally like this setup, for large computation it will anyway goes to the HPC.)
 mkdir .hq-server
 nohup hq worker start --cpus=2 --resource "mem=sum(2560)" --no-detect-resources &
+sleep 2
 nohup hq worker start --cpus=2 --resource "mem=sum(2560)" --no-detect-resources &
+
+# Setup the pw code
+verdi code create core.code.installed --non-interactive \
+  --label pw-7.2 \
+  --description "pw-7.2 run on hq local" \
+  --default-calc-job-plugin quantumespresso.pw \
+  --computer localhost-hq \
+  --prepend-text 'eval "$(conda shell.posix hook)"
+conda activate base
+export OMP_NUM_THREADS=1' \
+  --filepath-executable pw.x
+
+aiida-pseudo install sssp --functional PBE -p precision

--- a/stack/base/test_script.py
+++ b/stack/base/test_script.py
@@ -1,0 +1,136 @@
+"""Simple workflow example"""
+
+from aiida import orm
+from aiida.engine import Process, calcfunction, submit, workfunction
+from aiida.plugins import CalculationFactory, DataFactory, DbImporterFactory
+
+# Load the calculation class 'PwCalculation' using its entry point 'quantumespresso.pw'
+PwCalculation = CalculationFactory("quantumespresso.pw")
+KpointsData = DataFactory("array.kpoints")
+
+
+def generate_scf_input_params(structure, code, pseudo_family):
+    """Construct a builder for the `PwCalculation` class and populate its inputs.
+
+    :return: `ProcessBuilder` instance for `PwCalculation` with preset inputs
+    """
+    parameters = {
+        "CONTROL": {
+            "calculation": "scf",
+            "tstress": True,  # Important that this stays to get stress
+            "tprnfor": True,
+        },
+        "SYSTEM": {
+            "ecutwfc": 30.0,
+            "ecutrho": 200.0,
+        },
+        "ELECTRONS": {
+            "conv_thr": 1.0e-6,
+        },
+    }
+
+    kpoints = KpointsData()
+    kpoints.set_kpoints_mesh([2, 2, 2])
+
+    builder = PwCalculation.get_builder()
+    builder.code = code
+    builder.structure = structure
+    builder.kpoints = kpoints
+    builder.parameters = orm.Dict(dict=parameters)
+    builder.pseudos = pseudo_family.get_pseudos(structure=structure)
+    builder.metadata.options.resources = {"memory_mb": 1200, "num_cpus": 1}
+    builder.metadata.options.max_wallclock_seconds = 30 * 60
+
+    return builder
+
+
+@calcfunction
+def rescale(structure, scale):
+    """Calculation function to rescale a structure
+
+    :param structure: An AiiDA `StructureData` to rescale
+    :param scale: The scale factor (for the lattice constant)
+    :return: The rescaled structure
+    """
+    from aiida.orm import StructureData
+
+    ase_structure = structure.get_ase()
+    scale_value = scale.value
+
+    new_cell = ase_structure.get_cell() * scale_value
+    ase_structure.set_cell(new_cell, scale_atoms=True)
+
+    return StructureData(ase=ase_structure)
+
+
+@calcfunction
+def create_eos_dictionary(**kwargs):
+    """Create a single `Dict` node from the `Dict` output parameters of completed `PwCalculations`.
+
+    The dictionary will contain a list of tuples, where each tuple contains the volume, total energy and its units
+    of the results of a calculation.
+
+    :return: `Dict` node with the equation of state results
+    """
+    eos = [
+        (result.dict.volume, result.dict.energy, result.dict.energy_units)
+        for label, result in kwargs.items()
+    ]
+    return orm.Dict(dict={"eos": eos})
+
+
+@workfunction
+def run_eos_wf(code, pseudo_family_label, structure):
+    """Run an equation of state of a bulk crystal structure for the given element."""
+
+    # This will print the pk of the work function
+    print(f"Running run_eos_wf<{Process.current().pid}>")
+
+    scale_factors = (0.94, 0.96, 0.98, 1.0, 1.02, 1.04, 1.06)
+    labels = ["c1", "c2", "c3", "c4", "c5", "c6", "c7"]
+    pseudo_family = orm.load_group(pseudo_family_label.value)
+
+    calculations = {}
+
+    # Loop over the label and scale_factor pairs
+    for label, factor in list(zip(labels, scale_factors)):
+        # Generated the scaled structure from the initial structure
+        rescaled_structure = rescale(structure, orm.Float(factor))
+
+        # Generate the inputs for the `PwCalculation`
+        inputs = generate_scf_input_params(rescaled_structure, code, pseudo_family)
+
+        # Launch a `PwCalculation` for each scaled structure
+        print(f"Running a scf for {structure.get_formula()} with scale factor {factor}")
+        calculations[label] = submit(PwCalculation, **inputs)
+
+    ## Bundle the individual results from each `PwCalculation` in a single dictionary node.
+    ## Note: since we are 'creating' new data from existing data, we *have* to go through a `calcfunction`, otherwise
+    ## the provenance would be lost!
+    # inputs = {
+    #    label: result["output_parameters"] for label, result in calculations.items()
+    # }
+    # eos = create_eos_dictionary(**inputs)
+
+    ## Finally, return the eos Dict node
+    # return eos
+
+
+# load structure from COD
+CodDbImporter = DbImporterFactory("cod")
+cod = CodDbImporter()
+structure = cod.query(id="1526655")[0].get_aiida_structure()
+
+# If it is a cif file can import in CLI as
+# verdi data core.structure import ase /opt/examples/Si.cif
+
+# Code
+code = orm.load_code("pw-7.2@localhost-hq")
+
+# Pseudo
+pseudo_family_label = orm.Str("SSSP/1.3/PBE/precision")
+
+# Launch the workflow
+# result = run_eos_wf(code, pseudo_family_label, structure)
+# print(result)
+run_eos_wf(code, pseudo_family_label, structure)


### PR DESCRIPTION
- [ ] Use runOnce to manage the restart of hq.
- [ ] For hq on demo-server image, test 1. time  scaling of pw.x with mpiprocs number. 2. time of loading notebook when different number of pw.x is running.
- [ ] Understanding the behavior when number of workers decreases.