### PR TITLE
Increase the cull_inactive_interval for terminal app to 1 hour

### DIFF
--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -95,8 +95,8 @@ ENV NOTEBOOK_ARGS \
      "--MappingKernelManager.cull_connected=True" \
      "--MappingKernelManager.cull_idle_timeout=64800" \
      "--MappingKernelManager.cull_interval=300" \
-     "--TerminalManager.cull_inactive_timeout=600" \
-     "--TerminalManager.cull_interval=60"
+     "--TerminalManager.cull_inactive_timeout=3600" \
+     "--TerminalManager.cull_interval=300"
 
 # Set up the logo of notebook interface
 ARG PYTHON_MINOR_VERSION


### PR DESCRIPTION
While testing the DEMO server @cpignedoli noticed that the Terminal app auto-closes relatively quickly, which might be annoying to users. In this PR I am increasing the "culling" interval from 10 minutes to 1 hour. 