### PR TITLE
Adding the installation of h5py==3.11.0 in the dockerfile

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -15,15 +15,13 @@ ENV EXTRA_APT_PACKAGES "curl povray rsync build-essential"
 # For ARM64 we need to install erlang as it is not available on conda-forge
 # (this is needed later as rabbitmq dependency in base-with-services image,
 # but we install it here so that we don't have to invoke apt multiple times.
-# the h5py==3.11.0 is required in arm64 arch to install smoothly aiidalab-qe-vibroscopy.
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        EXTRA_APT_PACKAGES="erlang ${EXTRA_APT_PACKAGES}"; \
+        EXTRA_APT_PACKAGES="erlang libhdf5-serial-dev pkg-config ${EXTRA_APT_PACKAGES}"; \
     fi;\
     apt-get update --yes && \
     apt-get install --yes --no-install-recommends ${EXTRA_APT_PACKAGES} && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    mamba install --yes h5py==3.11.0
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/
 

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -15,13 +15,15 @@ ENV EXTRA_APT_PACKAGES "curl povray rsync build-essential"
 # For ARM64 we need to install erlang as it is not available on conda-forge
 # (this is needed later as rabbitmq dependency in base-with-services image,
 # but we install it here so that we don't have to invoke apt multiple times.
+# the h5py==3.11.0 is required in arm64 arch to install smoothly aiidalab-qe-vibroscopy.
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         EXTRA_APT_PACKAGES="erlang ${EXTRA_APT_PACKAGES}"; \
     fi;\
     apt-get update --yes && \
     apt-get install --yes --no-install-recommends ${EXTRA_APT_PACKAGES} && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mamba install --yes h5py==3.11.0
 
 WORKDIR /opt/
 


### PR DESCRIPTION
 Only if architecture is arm64. Otherwise the aiidalab-qe-vibroscopy plugin will fail to install. The reason is that we cannot install easily h5py via pip, for arm64.

This should solve issue https://github.com/aiidalab/aiidalab-qe/issues/745 and https://github.com/mikibonacci/aiidalab-qe-vibroscopy/issues/52