### PR TITLE
Increase minimum job poll interval to reduce verdi daemon CPU usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ on:
                 required: false
                 type: boolean
 
+env:
+    FORCE_COLOR: 1
+
 jobs:
 
     test:
@@ -53,5 +56,5 @@ jobs:
                   pip freeze
 
             - name: Run tests
-              run: pytest -m "${{ inputs.integration && 'integration' || 'not integration' }}" --target ${{inputs.target}}
+              run: pytest -s -m "${{ inputs.integration && 'integration' || 'not integration' }}" --target ${{inputs.target}}
               env: ${{ fromJSON(inputs.images) }}

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -64,11 +64,12 @@ if [[ ${NEED_SETUP_PROFILE} == true ]]; then
     # in verdi worker spinning at 100% CPU.
     # We set this to 2.0 seconds which should limit the CPU utilization below 10%.
     # https://aiida.readthedocs.io/projects/aiida-core/en/stable/howto/run_codes.html#mitigating-connection-overloads
+    job_poll_interval="2.0"
     python -c "
-        from aiida import load_profile;
-        from aiida.orm import load_computer;
-        load_profile();
-        load_computer(${computer_name}).set_minimum_job_poll_interval(2.0)"
+from aiida import load_profile; from aiida.orm import load_computer;
+load_profile();
+load_computer('${computer_name}').set_minimum_job_poll_interval(${job_poll_interval})
+"
 
 else
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,9 @@ def docker_compose_file(pytestconfig):
 @pytest.fixture(scope="session")
 def notebook_service(docker_ip, docker_services):
     """Ensure that HTTP service is up and responsive."""
+
+    # using `docker_compose` fixture would trigger a separate container
+    docker_compose = docker_services._docker_compose
     port = docker_services.port_for("aiidalab", 8888)
     url = f"http://{docker_ip}:{port}"
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,9 +68,11 @@ def notebook_service(docker_ip, docker_services):
         docker_services.wait_until_responsive(
             timeout=60.0, pause=0.1, check=lambda: is_responsive(url)
         )
-    except Exception:
+    except Exception as e:
         print(docker_compose.execute("logs").decode().strip())
-        raise
+        print(e)
+        # Let's exit hard, otherwise pytest output is a huge mess.
+        exit(1)
     return url
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,9 +73,8 @@ def notebook_service(docker_ip, docker_services):
         )
     except Exception as e:
         print(docker_compose.execute("logs").decode().strip())
-        print(e)
         # Let's exit hard, otherwise pytest output is a huge mess.
-        exit(1)
+        pytest.exit(e)
     return url
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,9 +64,13 @@ def notebook_service(docker_ip, docker_services):
     """Ensure that HTTP service is up and responsive."""
     port = docker_services.port_for("aiidalab", 8888)
     url = f"http://{docker_ip}:{port}"
-    docker_services.wait_until_responsive(
-        timeout=60.0, pause=0.1, check=lambda: is_responsive(url)
-    )
+    try:
+        docker_services.wait_until_responsive(
+            timeout=60.0, pause=0.1, check=lambda: is_responsive(url)
+        )
+    except Exception:
+        print(docker_compose.execute("logs").decode().strip())
+        raise
     return url
 
 


### PR DESCRIPTION
Closes #462 

I've selected the job poll interval of 2 seconds for now. This should keep the CPU utilization below 10% according to @cpignedoli benchmarks in #462. At the same time, 5s felt too long, since users might want to run super quick calculations to try things out. 

We can tweak this value after more benchmarking, but this feels like a reasonable first step.