### PR TITLE
Pin jupyter-notebook version

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -26,29 +26,34 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 WORKDIR /opt/
 
 ARG AIIDA_VERSION
-# Pin shared requirements in the base environment.
-# We pin aiida-core to the exact installed version,
-# to prevent accidental upgrade or downgrade, that might
+
+# Pin certain shared requirements in the base environment
+# so that user cannot change their version and accidently break themselves.
+# Pin aiida-core to the exact installed version
+# to prevent accidental upgrade or downgrade that might
 # induce DB migration or break shared dependencies of AiiDAlab Apps.
 RUN echo "aiida-core==${AIIDA_VERSION}" > /opt/requirements.txt
 
-# Install aiida-core and other shared requirements.
-RUN mamba install --yes \
-     mamba-bash-completion \
-     --file /opt/requirements.txt \
-     && mamba clean --all -f -y && \
-     fix-permissions "${CONDA_DIR}" && \
-     fix-permissions "/home/${NB_USER}"
+# Pin jupyter-notebook to prevent downgrades or upgrades to v7
+RUN echo "notebook==$(jupyter-notebook --version)" >> /opt/requirements.txt
 
-# Pin shared requirements in the conda base environment.
 RUN cat /opt/requirements.txt | xargs -I{} conda config --system --add pinned_packages {}
 
-# Upgrade pip to latest
-RUN pip install --upgrade --no-cache-dir pip
-# Configure pip to use requirements file as constraints file.
+# Configure pip to use the same requirements file as constraints file.
 ENV PIP_CONSTRAINT /opt/requirements.txt
 # Ensure that pip installs packages to ~/.local by default
 ENV PIP_USER 1
+
+# Upgrade pip to latest
+RUN mamba update -y pip && mamba clean --all -f -y
+
+# Install aiida-core and other shared requirements.
+RUN mamba install --yes \
+     aiida-core==${AIIDA_VERSION} \
+     mamba-bash-completion \
+     && mamba clean --all -f -y && \
+     fix-permissions "${CONDA_DIR}" && \
+     fix-permissions "/home/${NB_USER}"
 
 # Enable verdi autocompletion.
 RUN mkdir -p "${CONDA_DIR}/etc/conda/activate.d" && \

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -25,10 +25,32 @@ def test_prevent_installation_of_aiida(
         )
 
 
+@pytest.mark.parametrize("pkg_manager", ["pip", "mamba"])
+def test_prevent_notebook_upgrade(aiidalab_exec, nb_user, pkg_manager):
+    """jupyter-notebook is pinned to the exact version in the container,
+    test that both pip and mamba refuse to update to v7 of the notebook."""
+
+    incompatible_version = "7"
+    with pytest.raises(Exception):
+        aiidalab_exec(
+            f"{pkg_manager} install notebook=={incompatible_version}",
+            user=nb_user,
+        )
+
+
 def test_python_version(aiidalab_exec, python_version):
     info = json.loads(aiidalab_exec("mamba list --json --full-name python"))[0]
     assert info["name"] == "python"
     assert parse(info["version"]) == parse(python_version)
+
+
+def test_pip_version(aiidalab_exec):
+    """We update pip to latest version when building the image,
+    test that we're not using and old pip version"""
+
+    info = json.loads(aiidalab_exec("mamba list --json --full-name pip"))[0]
+    assert info["name"] == "pip"
+    assert parse(info["version"]) >= parse("24.0")
 
 
 def test_create_conda_environment(aiidalab_exec, nb_user):


### PR DESCRIPTION
In https://github.com/aiidalab/aiidalab-qe/issues/640, @superstar54 and I were debugging an issue with a stalled pip installation, likely caused by his quite complex dev environment. One thing I noticed that while the pip was trying hard to solve the dependencies, it started backtracking and looking at older versions of some of the core Jupyter libraries, most notably Jupyter notebook (`notebook` package). This is definitely not desirable, and if pip was able to finish, it would likely break the container. 

We've been having discussions in the past about pinning some jupyter-related packages to prevent this scenario from happening. I'll open a separate issue for that, but for starters I think we should pin at least the notebook package. We definitely don't want users to be able to downgrade the version, and we also don't want them to upgrade it, since we know that v7 will currently not work as it is a completely different architecture.