### PR TITLE
Use softprops/action-gh-release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,3 +111,16 @@ jobs:
             images: ${{ needs.build.outputs.images }}
             registry: docker.io
         secrets: inherit
+
+    make-release:
+        runs-on: ubuntu-22.04
+        if: >-
+            github.repository == 'aiidalab/aiidalab-docker-stack'
+            && github.ref_type == 'tag'
+        needs: [publish-dockerhub]
+
+        steps:
+            - uses: softprops/action-gh-release@v0.1.15
+              name: Create release
+              with:
+                  generate_release_notes: true


### PR DESCRIPTION
We haven't yet converted this repo to the new release workflow that we have e.g. for AWB so for now I am adding back a release step that automatically generates the release notes. Push to Dockerhub is still triggered by tag push as before.