### PR TITLE
Update aiida-core to 2.6.2

### DIFF
--- a/build.json
+++ b/build.json
@@ -10,7 +10,7 @@
       "default": "3.9.13"
     },
     "AIIDA_VERSION": {
-      "default": "2.5.1"
+      "default": "2.6.2"
     },
     "AIIDALAB_VERSION": {
       "default": "24.07.0"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,8 +10,11 @@ def test_notebook_service_available(notebook_service):
 
 def test_verdi_status(aiidalab_exec, nb_user):
     output = aiidalab_exec("verdi status", user=nb_user).strip()
-    assert "Connected to RabbitMQ" in output
+    for status in ("version", "config", "profile", "storage", "broker", "daemon"):
+        assert f"✔ {status}" in output
+    assert "/home/jovyan/.aiida" in output
     assert "Daemon is running" in output
+    assert "Unable to connect to broker" not in output
 
 
 def test_ssh_agent_is_running(aiidalab_exec, nb_user):


### PR DESCRIPTION
Looks like we're good to go here. I've launched tests for AWB in https://github.com/aiidalab/aiidalab-widgets-base/pull/616 and for QeApp in https://github.com/aiidalab/aiidalab-qe/pull/760 and they all passed.

Once we update, I think we can enable caching by default, per #407.