### PR TITLE
Updating the *before_notebook* `20_start-postgresql.sh` and `40_prepare_aiida.sh`

### DIFF
--- a/stack/base-with-services/before-notebook.d/20_start-postgresql.sh
+++ b/stack/base-with-services/before-notebook.d/20_start-postgresql.sh
@@ -22,10 +22,7 @@ else
     chmod -R g-rwxs "${PGDATA}"
 
     if [[ -f ${PGDATA}/logfile ]]; then
-        if [[ -f ${PSQL_LOGFILE}.1.gz ]]; then
-            echo "Deleting old ${PSQL_LOGFILE}.1.gz compressed file"
-            rm "${PSQL_LOGFILE}.1.gz"
-        fi
+        rm -f "${PSQL_LOGFILE}.1.gz" 
         mv "${PSQL_LOGFILE}" "${PSQL_LOGFILE}.1" && gzip "${PSQL_LOGFILE}.1"
     fi
     # Cleaning up the mess if PostgreSQL was not shutdown properly.

--- a/stack/base-with-services/before-notebook.d/20_start-postgresql.sh
+++ b/stack/base-with-services/before-notebook.d/20_start-postgresql.sh
@@ -22,7 +22,11 @@ else
     chmod -R g-rwxs "${PGDATA}"
 
     if [[ -f ${PGDATA}/logfile ]]; then
-         mv "${PSQL_LOGFILE}" "${PSQL_LOGFILE}.1" && gzip "${PSQL_LOGFILE}.1"
+        if [[ -f ${PSQL_LOGFILE}.1.gz ]]; then
+            echo "Deleting old ${PSQL_LOGFILE}.1.gz compressed file"
+            rm "${PSQL_LOGFILE}.1.gz"
+        fi
+        mv "${PSQL_LOGFILE}" "${PSQL_LOGFILE}.1" && gzip "${PSQL_LOGFILE}.1"
     fi
     # Cleaning up the mess if PostgreSQL was not shutdown properly.
     rm -vf "${PGDATA}/postmaster.pid"

--- a/stack/base-with-services/before-notebook.d/20_start-postgresql.sh
+++ b/stack/base-with-services/before-notebook.d/20_start-postgresql.sh
@@ -22,7 +22,7 @@ else
     chmod -R g-rwxs "${PGDATA}"
 
     if [[ -f ${PGDATA}/logfile ]]; then
-        rm -f "${PSQL_LOGFILE}.1.gz" 
+        rm -f "${PSQL_LOGFILE}.1.gz"
         mv "${PSQL_LOGFILE}" "${PSQL_LOGFILE}.1" && gzip "${PSQL_LOGFILE}.1"
     fi
     # Cleaning up the mess if PostgreSQL was not shutdown properly.

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -76,7 +76,7 @@ else
   # Migration will run for the default profile.
   pgrep -af 'verdi.* daemon' && echo "ERROR: AiiDA daemon is already running!" && exit 1
   ## clean up stale PID-files -> .aiida/daemon/circus-{profile-name}.pid
-  rm -f "/home/${NB_USER}/.aiida/daemon/circus-*.pid"
+  rm -f /home/${NB_USER}/.aiida/daemon/circus-*.pid
   verdi storage migrate --force
 
 fi

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -74,8 +74,8 @@ load_computer('${computer_name}').set_minimum_job_poll_interval(${job_poll_inter
 else
 
   # Migration will run for the default profile.
-  ## We need to stop the daemon before.
-  verdi daemon stop
+  ## clean up stale PID-files -> .aiida/daemon/circus-{profile-name}.pid
+  rm -f "/home/${NB_USER}/.aiida/daemon/circus-${AIIDA_PROFILE_NAME}.pid"
   verdi storage migrate --force
 
 fi

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -74,6 +74,8 @@ load_computer('${computer_name}').set_minimum_job_poll_interval(${job_poll_inter
 else
 
   # Migration will run for the default profile.
+  ## We need to stop the daemon before. 
+  verdi daemon stop
   verdi storage migrate --force
 
 fi

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -74,6 +74,7 @@ load_computer('${computer_name}').set_minimum_job_poll_interval(${job_poll_inter
 else
 
   # Migration will run for the default profile.
+  pgrep -af 'verdi.* daemon' && echo "ERROR: AiiDA daemon is already running!" && exit 1
   ## clean up stale PID-files -> .aiida/daemon/circus-{profile-name}.pid
   rm -f "/home/${NB_USER}/.aiida/daemon/circus-*.pid"
   verdi storage migrate --force

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -75,7 +75,7 @@ else
 
   # Migration will run for the default profile.
   ## clean up stale PID-files -> .aiida/daemon/circus-{profile-name}.pid
-  rm -f "/home/${NB_USER}/.aiida/daemon/circus-${AIIDA_PROFILE_NAME}.pid"
+  rm -f "/home/${NB_USER}/.aiida/daemon/circus-*.pid"
   verdi storage migrate --force
 
 fi

--- a/stack/base/before-notebook.d/40_prepare-aiida.sh
+++ b/stack/base/before-notebook.d/40_prepare-aiida.sh
@@ -74,7 +74,7 @@ load_computer('${computer_name}').set_minimum_job_poll_interval(${job_poll_inter
 else
 
   # Migration will run for the default profile.
-  ## We need to stop the daemon before. 
+  ## We need to stop the daemon before.
   verdi daemon stop
   verdi storage migrate --force
 


### PR DESCRIPTION
Fixings are done as for arm64 I encountered issues in restarting the container.

1 - Deleting old ${PSQL_LOGFILE}.1.gz file before trying to compressed again in `20_start-postgresql.sh`. Otherwise, this can give errors and so the container will exit with non-zero status. 
2 - Clean stop of the daemon before the "verdi storage migrate --force" in `40_prepare_aiida.sh`. This is done because sometimes the restart of the docker container will give error in trying to migrate, as the daemon is still running. I am not able to reproduce the error in a standard way, however.