### PR TITLE
Update aiidalab package to 24.7

### DIFF
--- a/build.json
+++ b/build.json
@@ -13,7 +13,7 @@
       "default": "2.5.1"
     },
     "AIIDALAB_VERSION": {
-      "default": "23.03.2"
+      "default": "24.07.0"
     },
     "AIIDALAB_HOME_VERSION": {
       "default": "23.03.1"

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -44,11 +44,10 @@ ENV PIP_CONSTRAINT /opt/requirements.txt
 # Ensure that pip installs packages to ~/.local by default
 ENV PIP_USER 1
 
-# Upgrade pip to latest
-RUN mamba update -y pip && mamba clean --all -f -y
-
+# Upgrade pip and mamba to latest
 # Install aiida-core and other shared requirements.
-RUN mamba install --yes \
+RUN mamba update -y pip && \
+     mamba install --yes \
      aiida-core==${AIIDA_VERSION} \
      mamba-bash-completion \
      && mamba clean --all -f -y && \


### PR DESCRIPTION
This is a minor update, mostly important for later when we switch to Python 3.11 in #455, but let's deploy it now.
Changelog available here: 

https://github.com/aiidalab/aiidalab/releases/tag/v24.07.0