### PR TITLE
Fix integration tests

### DIFF
--- a/tests/test_aiidalab_apps.py
+++ b/tests/test_aiidalab_apps.py
@@ -35,6 +35,11 @@ def generate_aiidalab_install_output(aiidalab_exec, nb_user):
     if pkg:
         app_name = pkg.split("@")[0]
         aiidalab_exec(f"aiidalab uninstall --yes --force {app_name}", user=nb_user)
+        # TODO: Remove this after solving https://github.com/aiidalab/aiidalab/issues/405
+        pkg_name = app_name
+        if app_name.lower() == "quantum-espresso":
+            pkg_name = "aiidalab-qe"
+        aiidalab_exec(f"pip uninstall --yes {pkg_name}", user=nb_user)
 
 
 @pytest.mark.parametrize("package_name", ["aiidalab-widgets-base", "quantum-espresso"])


### PR DESCRIPTION
One of the integration test is currently failing since the new alpha release of AWB because when we uninstall the app do do not uninstall the corresponding python package from the Python environment, leading to a `pip check` failing in the next test. This is filed as a bug in `aiidalab` https://github.com/aiidalab/aiidalab/issues/405

```
FAILED tests/test_aiidalab_apps.py::test_install_apps_from_default_branch[aiidalab-widgets-base]
Command docker compose -f "stack/docker-compose.full-stack.yml" -p "pytest1774" exec -T --user=jovyan 
aiidalab pip check returned 1:
aiidalab-qe 24.10.0a1 has requirement aiidalab-widgets-base[optimade]<2.4.0,~=2.2.0, 
but you have aiidalab-widgets-base 2.3.0a1.
```

Until that is solved, I modified the fixture to uninstall the pip package corresponding to the App. 
(Annoyingly, I needed to special-case `aiidalab-qe` since the name of the python package `aiidalab-qe` is different from the name of the app in the registry (`quantum-espresso`).