### PR TITLE
Preinstall AWB in lab image

### DIFF
--- a/build.json
+++ b/build.json
@@ -15,6 +15,9 @@
     "AIIDALAB_VERSION": {
       "default": "26.06.0"
     },
+    "AWB_VERSION": {
+      "default": "3.0.0a2"
+    },
     "AIIDALAB_HOME_TAG": {
       "default": "v26.06.0"
     }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,6 +17,9 @@ variable "AIIDA_VERSION" {
 variable "AIIDALAB_VERSION" {
 }
 
+variable "AWB_VERSION" {
+}
+
 variable "AIIDALAB_HOME_TAG" {
 }
 
@@ -88,6 +91,7 @@ target "lab" {
   args = {
     "AIIDALAB_VERSION"      = "${AIIDALAB_VERSION}"
     "AIIDALAB_HOME_TAG" = "${AIIDALAB_HOME_TAG}"
+    "AWB_VERSION"      = "${AWB_VERSION}"
     "PYTHON_MINOR_VERSION" = get_python_minor_version("${PYTHON_VERSION}")
   }
 }

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -63,7 +63,7 @@ COPY pip.conf "${CONDA_DIR}/pip.conf"
 # https://github.com/aiidalab/aiidalab-widgets-base/issues/733
 RUN mamba update -y pip async_generator certipy && \
      mamba install --yes \
-     aiida-core=${AIIDA_VERSION} \
+     aiida-core.atomic_tools==${AIIDA_VERSION} \
      numpy=1.* \
      mamba-bash-completion \
      && mamba clean --all -f -y && \

--- a/stack/lab/Dockerfile
+++ b/stack/lab/Dockerfile
@@ -11,11 +11,12 @@ ENV DOCKER_STACKS_JUPYTER_CMD=nbclassic
 USER root
 WORKDIR /opt/
 
-# Install aiidalab package
 ARG AIIDALAB_VERSION
+ARG AWB_VERSION
 RUN mamba install --yes \
      aiidalab=${AIIDALAB_VERSION} \
      appmode=1.1.0 \
+     aiidalab-widgets-base=${AWB_VERSION} \
      && mamba clean --all -f -y && \
      fix-permissions "${CONDA_DIR}" && \
      fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
The goal here is to pre-install AWB into the image from a conda package to:

- speed up the installation of apps that depend on AWB
- make the image more robust by pre-installing the often-used  dependencies into the conda environment so that they don't need to be installed from PyPI by pip into `~/.local`
- relatedly, this PR also proposes to pre-install the `atomic_tools` extras from aiida-core which share a lot of the packages with AWB (e.g. ase) and so it is generally good to ensure that the supported versions are compatible with each other. Also, `atomic_tools` includes pymatgen and scipy, which we had issues with installing from PyPI before (see #526)

Obviously, the big disadvantage is the size of the image, but to me the increase stability seems worth it. Also, applications dependending on AWB (like QeApp) would end up installing the packages anyways, and installing them from conda is actually generally more efficient since conda packages do not vendor non-python code).

NOTE: We cannot **pin** the exact AWB version, because apps need to be able to upgrade or even downgrade the pre-installed version according to their needs. But the thesis is that most of the AWB dependencies are not changed in between AWB versions and so it still makes sense to have them pre-installed. We probably can specify the lowest supported AWB version (which since this is build on the python 3.12 image will be AWB 3.0)

Staged on top of #455

Closes #526