### PR TITLE
Add pip.conf

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -42,7 +42,7 @@ RUN cat /opt/requirements.txt | xargs -I{} conda config --system --add pinned_pa
 # Configure pip to use the same requirements file as constraints file.
 ENV PIP_CONSTRAINT /opt/requirements.txt
 # Ensure that pip installs packages to ~/.local by default
-ENV PIP_USER 1
+COPY pip.conf /etc/pip.conf
 
 # Upgrade pip and mamba to latest
 # Install aiida-core and other shared requirements.

--- a/stack/base/pip.conf
+++ b/stack/base/pip.conf
@@ -1,0 +1,2 @@
+[install]
+user = true


### PR DESCRIPTION
Follow up to #437. Fixes #484 (see this issue for more details)

PIP_USER envvar affects all pip subcommands, including `pip list`  which had unintended side effects. Using the pip.conf file allows to set `--user` specifically for the `install` subcommand.

