### PR TITLE
Fix `pip check` test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
         needs: [publish-dockerhub]
 
         steps:
-            - uses: softprops/action-gh-release@v2.0.6
+            - uses: softprops/action-gh-release@v2
               name: Create release
               with:
                   generate_release_notes: true

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -45,14 +45,15 @@ ENV PIP_CONSTRAINT /opt/requirements.txt
 COPY pip.conf /etc/pip.conf
 
 # Upgrade pip and mamba to latest
+# Update async_generator, certipy to satisfy `pip check`
+# https://github.com/aiidalab/aiidalab-docker-stack/issues/490
 # Install aiida-core and other shared requirements.
-RUN mamba update -y pip && \
+RUN mamba update -y pip async_generator certipy && \
      mamba install --yes \
      aiida-core==${AIIDA_VERSION} \
      mamba-bash-completion \
      && mamba clean --all -f -y && \
-     fix-permissions "${CONDA_DIR}" && \
-     fix-permissions "/home/${NB_USER}"
+     fix-permissions "${CONDA_DIR}"
 
 # Enable verdi autocompletion.
 RUN mkdir -p "${CONDA_DIR}/etc/conda/activate.d" && \


### PR DESCRIPTION
Fixes #490. The offending packages have been fixed upstream, but we need to forcibly update `async_generator` and `certipy` to pick up those changes since these are already part of the jupyter base image.

Additionally, I've unpinned the `softprops/actions-gh-release` action.
Pinning this action to specific patch version just creates noise from dependabot. Given that we currently don't pin any other actions to the exact versions, let's unpin this one as well.

Closes #487 