### PR TITLE
Fix pre-commit in the image

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -43,7 +43,8 @@ RUN cat /opt/requirements.txt | xargs -I{} conda config --system --add pinned_pa
 # Configure pip to use the same requirements file as constraints file.
 ENV PIP_CONSTRAINT /opt/requirements.txt
 # Ensure that pip installs packages to ~/.local by default
-COPY pip.conf /etc/pip.conf
+RUN mkdir -p "${NB_USER}/.config/pip"
+COPY pip.conf "${NB_USER}/.config/pip/pip.conf"
 
 # Upgrade pip and mamba to latest
 # Update async_generator, certipy to satisfy `pip check`

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -42,9 +42,19 @@ RUN cat /opt/requirements.txt | xargs -I{} conda config --system --add pinned_pa
 
 # Configure pip to use the same requirements file as constraints file.
 ENV PIP_CONSTRAINT /opt/requirements.txt
-# Ensure that pip installs packages to ~/.local by default
-RUN mkdir -p "${NB_USER}/.config/pip"
-COPY pip.conf "${NB_USER}/.config/pip/pip.conf"
+# Ensure that pip installs packages to '~/.local/lib/python3.X/site-packages/' by default
+# by implicitly passing the '--user' option to 'pip install'
+# Otherwise, pip would install into /opt/conda and such packages would be lost
+# when the container exits.
+# NOTE: We specifically chose the location '/opt/conda/pip.conf'
+# which represents the 'site' config file when VIRTUAL_ENV is not set, per:
+# https://pip.pypa.io/en/stable/topics/configuration/#configuration-files
+# Other locations such as '~/.config/pip/pip.conf' or '/etc/pip.conf' would interfere with virtual environments,
+# for example those used by pre-commit.
+# We can't use the PIP_USER env variable for the same reason.
+# To better understand this, try running `pip config debug` and see
+# https://github.com/aiidalab/aiidalab-docker-stack/issues/501
+COPY pip.conf "${CONDA_DIR}/pip.conf"
 
 # Upgrade pip and mamba to latest
 # Update async_generator, certipy to satisfy `pip check`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,11 +112,11 @@ def pip_install(aiidalab_exec, nb_user):
     def _pip_install(pkg, **args):
         nonlocal package
         package = pkg
-        return aiidalab_exec(f"pip install {pkg}", **args)
+        return aiidalab_exec(f"pip install {pkg}", user=nb_user, **args)
 
     yield _pip_install
     if package:
-        aiidalab_exec(f"pip uninstall --yes {package}")
+        aiidalab_exec(f"pip uninstall --yes {package}", user=nb_user)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -80,7 +80,7 @@ def test_pip_user_install(aiidalab_exec, pip_install, nb_user):
 
     # We use 'tuna' as an example of python-only package without dependencies
     pkg = "tuna"
-    pip_install(pkg)
+    pip_install(pkg, user=nb_user)
     output = aiidalab_exec(f"pip show {pkg}")
 
     # `pip show` output is in the RFC-compliant email header format


### PR DESCRIPTION
Fixes pre-commit by moving the pip.conf configuration (which automatically sets the `--user` option to `pip install`)  from the global `etc/pip.conf` to site-specific `/opt/conda/pip.conf`. In this way, the configuration does not mess with virtual environments. See the long comment in the Dockerfile for detailed explanation.

Fixes #501 