### PR TITLE
Update RMQ to 3.10.25

### DIFF
--- a/build.json
+++ b/build.json
@@ -7,7 +7,7 @@
       "default": "15"
     },
     "RMQ_VERSION": {
-      "default": "3.9.13"
+      "default": "3.10.25"
     },
     "AIIDA_VERSION": {
       "default": "2.6.3"


### PR DESCRIPTION
For now I'm just testing if we can straightforwardly update to 3.10 from 3.9

See:
https://www.rabbitmq.com/docs/which-erlang#old-timers
https://www.rabbitmq.com/docs/upgrade#rabbitmq-version-upgradability

TODO:
 - The arm64 build will be broken here since the system erlang will be incompatible