### PR TITLE
Cleanup docker-compose config files

### DIFF
--- a/stack/docker-compose.base-with-services.yml
+++ b/stack/docker-compose.base-with-services.yml
@@ -1,15 +1,11 @@
 ---
-version: '3.4'
-
 services:
 
     aiidalab:
         image: ${REGISTRY:-}${BASE_WITH_SERVICES_IMAGE:-aiidalab/base-with-services}${VERSION:-}
         environment:
             TZ: Europe/Zurich
-            DOCKER_STACKS_JUPYTER_CMD: notebook
             SETUP_DEFAULT_AIIDA_PROFILE: 'true'
-            AIIDALAB_DEFAULT_APPS: ''
         volumes:
             - aiidalab-home-folder:/home/jovyan
         ports:

--- a/stack/docker-compose.base.yml
+++ b/stack/docker-compose.base.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.4'
-
 services:
 
     database:
@@ -29,9 +27,7 @@ services:
         environment:
             RMQHOST: messaging
             TZ: Europe/Zurich
-            DOCKER_STACKS_JUPYTER_CMD: notebook
             SETUP_DEFAULT_AIIDA_PROFILE: 'true'
-            AIIDALAB_DEFAULT_APPS: ''
         volumes:
             - aiidalab-home-folder:/home/jovyan
         depends_on:

--- a/stack/docker-compose.full-stack.yml
+++ b/stack/docker-compose.full-stack.yml
@@ -1,15 +1,11 @@
 ---
-version: '3.4'
-
 services:
 
     aiidalab:
         image: ${REGISTRY:-}${FULL_STACK_IMAGE:-aiidalab/full-stack}${VERSION:-}
         environment:
             TZ: Europe/Zurich
-            DOCKER_STACKS_JUPYTER_CMD: notebook
             SETUP_DEFAULT_AIIDA_PROFILE: 'true'
-            AIIDALAB_DEFAULT_APPS: ''
         volumes:
             - aiidalab-home-folder:/home/jovyan
         ports:

--- a/stack/docker-compose.lab.yml
+++ b/stack/docker-compose.lab.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.4'
-
 services:
 
     database:
@@ -29,9 +27,7 @@ services:
         environment:
             RMQHOST: messaging
             TZ: Europe/Zurich
-            DOCKER_STACKS_JUPYTER_CMD: notebook
             SETUP_DEFAULT_AIIDA_PROFILE: 'true'
-            AIIDALAB_DEFAULT_APPS: ''
         volumes:
             - aiidalab-home-folder:/home/jovyan
         depends_on:


### PR DESCRIPTION
It's pointless to specify DOCKER_STACKS_JUPYTER_CMD envvar since that is controlled by the Dockerfile, and cannot really be changes externally without breaking the image.

Split from #479