### PR TITLE
Pin numpy to 1.x

### DIFF
--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -60,9 +60,12 @@ COPY pip.conf "${CONDA_DIR}/pip.conf"
 # Update async_generator, certipy to satisfy `pip check`
 # https://github.com/aiidalab/aiidalab-docker-stack/issues/490
 # Install aiida-core and other shared requirements.
+# We need to pin numpy to 1.x due to AWB using old bokeh version, see:
+# https://github.com/aiidalab/aiidalab-widgets-base/issues/733
 RUN mamba update -y pip async_generator certipy && \
      mamba install --yes \
-     aiida-core==${AIIDA_VERSION} \
+     aiida-core=${AIIDA_VERSION} \
+     numpy=1.* \
      mamba-bash-completion \
      traitlets=5.9.0 \
      && mamba clean --all -f -y && \


### PR DESCRIPTION
The current bokeh version in AWB is incompatible with numpy 2.x There might also be other issues in existing apps so for now we'll pin numpy to 1.x

See https://github.com/aiidalab/aiidalab-widgets-base/issues/733 for more detail