### PR TITLE
Revert "Bump AiiDA to aiida-core==2.8.0 (#551)"

### DIFF
--- a/build.json
+++ b/build.json
@@ -10,7 +10,7 @@
       "default": "3.10.25"
     },
     "AIIDA_VERSION": {
-      "default": "2.8.0"
+      "default": "2.7.3"
     },
     "AIIDALAB_VERSION": {
       "default": "26.05.2"


### PR DESCRIPTION
This reverts commit 32a575930cf13fab04d2446a2514089e830b77d4.

This is a temporary revert of aiida-core bump so we can make a one last release of python 3.9 docker stack, which will include #563 and #560.