### PR TITLE
Update AWB to v3.0.0a3

### DIFF
--- a/build.json
+++ b/build.json
@@ -16,7 +16,7 @@
       "default": "26.06.0"
     },
     "AWB_VERSION": {
-      "default": "3.0.0a2"
+      "default": "3.0.0a3"
     },
     "AIIDALAB_HOME_TAG": {
       "default": "v26.06.0"

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -56,10 +56,8 @@ ENV PIP_CONSTRAINT=/opt/requirements.txt
 COPY pip.conf "${CONDA_DIR}/pip.conf"
 
 # Upgrade pip and mamba to latest
-# Update async_generator, certipy to satisfy `pip check`
-# https://github.com/aiidalab/aiidalab-docker-stack/issues/490
 # Install aiida-core and other shared requirements.
-RUN mamba update -y pip async_generator certipy && \
+RUN mamba update -y pip && \
      mamba install --yes \
      aiida-core.atomic_tools==${AIIDA_VERSION} \
      mamba-bash-completion \

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -57,7 +57,7 @@ COPY pip.conf "${CONDA_DIR}/pip.conf"
 
 # Upgrade pip and mamba to latest
 # Install aiida-core and other shared requirements.
-RUN mamba update -y pip && \
+RUN mamba update -y pip mamba && \
      mamba install --yes \
      aiida-core.atomic_tools==${AIIDA_VERSION} \
      mamba-bash-completion \

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -59,12 +59,9 @@ COPY pip.conf "${CONDA_DIR}/pip.conf"
 # Update async_generator, certipy to satisfy `pip check`
 # https://github.com/aiidalab/aiidalab-docker-stack/issues/490
 # Install aiida-core and other shared requirements.
-# We need to pin numpy to 1.x due to AWB using old bokeh version, see:
-# https://github.com/aiidalab/aiidalab-widgets-base/issues/733
 RUN mamba update -y pip async_generator certipy && \
      mamba install --yes \
      aiida-core.atomic_tools==${AIIDA_VERSION} \
-     numpy=1.* \
      mamba-bash-completion \
      && mamba clean --all -f -y && \
      fix-permissions "${CONDA_DIR}"

--- a/stack/base/Dockerfile
+++ b/stack/base/Dockerfile
@@ -57,7 +57,7 @@ COPY pip.conf "${CONDA_DIR}/pip.conf"
 
 # Upgrade pip and mamba to latest
 # Install aiida-core and other shared requirements.
-RUN mamba update -y pip mamba && \
+RUN mamba update -y pip && \
      mamba install --yes \
      aiida-core.atomic_tools==${AIIDA_VERSION} \
      mamba-bash-completion \


### PR DESCRIPTION
~~Blocked on https://github.com/aiidalab/aiidalab-widgets-base/pull/763~~

Tested that the image now has numpy 2.x installed

```console
$ podman run --entrypoint "bash" ghcr.io/aiidalab/full-stack:pr-573 -c "pip show numpy"
Name: numpy
Version: 2.4.6
Summary: Fundamental package for array computing in Python
Home-page: https://numpy.org
Author: Travis E. Oliphant et al.
Author-email: 
License-Expression: BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0
Location: /opt/conda/lib/python3.12/site-packages
Requires: 
Required-by: aiida-core, ase, contourpy, matplotlib, monty, nglview, pandas, PyCifRW, pymatgen, scipy, seekpath, spglib
```

The image got 80Mb smaller, probably thanks to dropping bokeh from dependencies :-) 
```console
$ podman images
REPOSITORY                     TAG         IMAGE ID      CREATED        SIZE
ghcr.io/aiidalab/full-stack    pr-573      4016d8a75dc1  3 hours ago    3.56 GB
ghcr.io/aiidalab/full-stack    edge        930234d091a4  11 days ago    3.64 GB
```