### PR TITLE
quote the bake metadata heredoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
             # https://github.com/aiidalab/aiidalab-docker-stack/issues/493
             - name: Write metadata output to a json file
               run: |
-                  cat << EOF > bake_metadata.json
+                  cat << 'EOF' > bake_metadata.json
                   ${{ steps.build-upload.outputs.metadata }}
                   EOF
 


### PR DESCRIPTION
Same change as was done in aiidateam/aiida-core#7449, see that PR for details.

Notably, the metadata's buildx.build.provenance embeds the push event payload, commit messages included, so every backtick in a commit message is treated as command substitution!