### PR TITLE
Fix removal of temporary notebooks

### DIFF
--- a/stack/lab/before-notebook.d/60_prepare-aiidalab.sh
+++ b/stack/lab/before-notebook.d/60_prepare-aiidalab.sh
@@ -52,7 +52,7 @@ fi
 find -L /home/${NB_USER} -maxdepth 3 -name apps_meta.sqlite -writable -delete
 
 # Remove old temporary notebook files.
-find -L /home/${NB_USER}/apps -maxdepth 2 -type f -name .*.ipynb -writable -delete
+find -L /home/${NB_USER}/apps -maxdepth 2 -type f -name '.*.ipynb' -writable -delete
 
 # Uninstall aiidalab from user packages (if present).
 # Would otherwise interfere with the system package.


### PR DESCRIPTION
fix #578

Update the notebook wildcard so bash doesn't interpret it.